### PR TITLE
fix(network): preserve spaces in map names

### DIFF
--- a/Core/GameEngine/Source/GameNetwork/GameInfo.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameInfo.cpp
@@ -1000,8 +1000,8 @@ AsciiString GameInfoToAsciiString( const GameInfo *game )
 	return optionsString;
 }
 
-// GeneralsX @feature fbraz 05/05/2026 Support special characters in map names via percent encoding.
-// This allows map names with brackets, spaces, and other chars commonly used by C&C community mapmakers.
+// GeneralsX @feature fbraz 05/05/2026 Support reserved characters in map names via percent encoding.
+// GeneralsX @bugfix arazmj 14/08/2026 Keep spaces literal for network compatibility with TheSuperHackers builds.
 static AsciiString percentEncodeMapName(const AsciiString& mapName)
 {
 	// Characters that MUST be encoded in replay header field values:
@@ -1010,7 +1010,6 @@ static AsciiString percentEncodeMapName(const AsciiString& mapName)
 	// ] (0x5D) - INI section marker  
 	// ; (0x3B) - field separator in replay header
 	// = (0x3D) - key-value separator in replay header
-	// Space (0x20) - for safety with paths
 	AsciiString result;
 	const char* src = mapName.str();
 	
@@ -1022,7 +1021,6 @@ static AsciiString percentEncodeMapName(const AsciiString& mapName)
 			case ']':  result.concat("%5D"); break;
 			case ';':  result.concat("%3B"); break;
 			case '=':  result.concat("%3D"); break;
-			case ' ':  result.concat("%20"); break;
 			default:   result.concat(src[i]); break;
 		}
 	}
@@ -1753,5 +1751,4 @@ void SkirmishGameInfo::xfer( Xfer *xfer )
 void SkirmishGameInfo::loadPostProcess()
 {
 }
-
 

--- a/docs/WORKLOG/2026-08-DIARY.md
+++ b/docs/WORKLOG/2026-08-DIARY.md
@@ -1,5 +1,10 @@
 # August 2026
 
+## 14/08/2026
+### Restore Windows LAN Map Compatibility
+- Kept spaces literal when serializing map names so TheSuperHackers Windows builds can resolve official maps such as Twilight Flame.
+- Preserved percent decoding for compatibility with existing GeneralsX replays and reserved-character map names.
+
 ## 11/08/2026
 ### Upstream Sync from TheSuperHackers (`thesuperhackers/main`)
 - Created sync branch `thesuperhackers-sync-08-10-2026` and merged upstream `thesuperhackers/main`.


### PR DESCRIPTION
## Description

Keep spaces literal when serializing map names so current GeneralsX hosts remain compatible with TheSuperHackers Windows clients.

GeneralsX encoded `Twilight Flame` as `Twilight%20Flame`. The upstream Windows parser does not percent-decode map names, so it searched its map cache for a nonexistent path and reported that the player could not find the map.

Reserved field delimiters remain percent-encoded, and the existing decoder remains in place for GeneralsX replays that already contain `%20`.

## Validation

- Built the `macos-vulkan` Zero Hour target
- Bundled and launched the patched `GeneralsXZH.app`
- Confirmed the game reached its normal SDL3/DXVK startup without errors
