### PR TITLE
fix(containment): allow shared network exits

### DIFF
--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
@@ -63,7 +63,49 @@
 #include "GameLogic/Module/DeliverPayloadAIUpdate.h"
 #include "GameLogic/Module/HackInternetAIUpdate.h"
 #include "GameLogic/Module/HordeUpdate.h"
+#include "GameLogic/Module/BehaviorModule.h"
 #include "GameLogic/Object.h"
+
+// GeneralsX @bugfix GitHubCopilot 15/08/2026 Allow same-player tunnel and cave networks to exit through another endpoint.
+static Bool isCaveContainer(const Object *obj)
+{
+	if (!obj)
+		return FALSE;
+
+	for (BehaviorModule **module = obj->getBehaviorModules(); *module; ++module)
+	{
+		if ((*module)->getCaveInterface() != nullptr)
+			return TRUE;
+	}
+
+	return FALSE;
+}
+
+static Bool isSharedNetworkExitContainer(const Object *fromContainer, const Object *toContainer)
+{
+	if (!fromContainer || !toContainer)
+		return FALSE;
+
+	const ContainModuleInterface *fromContain = fromContainer->getContain();
+	const ContainModuleInterface *toContain = toContainer->getContain();
+	if (!fromContain || !toContain)
+		return FALSE;
+
+	const Player *fromPlayer = fromContainer->getControllingPlayer();
+	const Player *toPlayer = toContainer->getControllingPlayer();
+	if (!fromPlayer || fromPlayer != toPlayer)
+		return FALSE;
+
+	const ContainedItemsList *fromItems = fromContain->getContainedItemsList();
+	const ContainedItemsList *toItems = toContain->getContainedItemsList();
+	if (!fromItems || fromItems != toItems)
+		return FALSE;
+
+	if (fromContain->isTunnelContain() && toContain->isTunnelContain())
+		return TRUE;
+
+	return isCaveContainer(fromContainer) && isCaveContainer(toContainer);
+}
 #include "GameLogic/PartitionManager.h"
 #include "GameLogic/PolygonTrigger.h"
 #include "GameLogic/ScriptEngine.h"
@@ -3677,10 +3719,14 @@ void AIUpdateInterface::privateExit( Object *objectToExit, CommandSourceType cmd
 		// TheSuperHackers @bugfix Caball009 10/08/2026 Don't process invalid exit commands,
 		// because an object should not attempt to exit something it's not contained by.
 #if !RETAIL_COMPATIBLE_CRC
-		// @todo Remove function parameter 'objectToExit' because it's become obsolete.
-
 		if (us->getContainedBy() != objectToExit)
-			return;
+		{
+			const Player *unitPlayer = us->getControllingPlayer();
+			const Player *exitPlayer = objectToExit ? objectToExit->getControllingPlayer() : nullptr;
+			if (!unitPlayer || unitPlayer != exitPlayer
+				|| !isSharedNetworkExitContainer(us->getContainedBy(), objectToExit))
+				return;
+		}
 #endif
 	}
 

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/AIUpdate.cpp
@@ -63,7 +63,49 @@
 #include "GameLogic/Module/DeliverPayloadAIUpdate.h"
 #include "GameLogic/Module/HackInternetAIUpdate.h"
 #include "GameLogic/Module/HordeUpdate.h"
+#include "GameLogic/Module/BehaviorModule.h"
 #include "GameLogic/Object.h"
+
+// GeneralsX @bugfix GitHubCopilot 15/08/2026 Allow same-player tunnel and cave networks to exit through another endpoint.
+static Bool isCaveContainer(const Object *obj)
+{
+	if (!obj)
+		return FALSE;
+
+	for (BehaviorModule **module = obj->getBehaviorModules(); *module; ++module)
+	{
+		if ((*module)->getCaveInterface() != nullptr)
+			return TRUE;
+	}
+
+	return FALSE;
+}
+
+static Bool isSharedNetworkExitContainer(const Object *fromContainer, const Object *toContainer)
+{
+	if (!fromContainer || !toContainer)
+		return FALSE;
+
+	const ContainModuleInterface *fromContain = fromContainer->getContain();
+	const ContainModuleInterface *toContain = toContainer->getContain();
+	if (!fromContain || !toContain)
+		return FALSE;
+
+	const Player *fromPlayer = fromContainer->getControllingPlayer();
+	const Player *toPlayer = toContainer->getControllingPlayer();
+	if (!fromPlayer || fromPlayer != toPlayer)
+		return FALSE;
+
+	const ContainedItemsList *fromItems = fromContain->getContainedItemsList();
+	const ContainedItemsList *toItems = toContain->getContainedItemsList();
+	if (!fromItems || fromItems != toItems)
+		return FALSE;
+
+	if (fromContain->isTunnelContain() && toContain->isTunnelContain())
+		return TRUE;
+
+	return isCaveContainer(fromContainer) && isCaveContainer(toContainer);
+}
 #include "GameLogic/PartitionManager.h"
 #include "GameLogic/PolygonTrigger.h"
 #include "GameLogic/ScriptEngine.h"
@@ -3832,10 +3874,14 @@ void AIUpdateInterface::privateExit( Object *objectToExit, CommandSourceType cmd
 		// TheSuperHackers @bugfix Caball009 10/08/2026 Don't process invalid exit commands,
 		// because an object should not attempt to exit something it's not contained by.
 #if !RETAIL_COMPATIBLE_CRC
-		// @todo Remove function parameter 'objectToExit' because it's become obsolete.
-
 		if (us->getContainedBy() != objectToExit)
-			return;
+		{
+			const Player *unitPlayer = us->getControllingPlayer();
+			const Player *exitPlayer = objectToExit ? objectToExit->getControllingPlayer() : nullptr;
+			if (!unitPlayer || unitPlayer != exitPlayer
+				|| !isSharedNetworkExitContainer(us->getContainedBy(), objectToExit))
+				return;
+		}
 #endif
 	}
 
@@ -3871,10 +3917,14 @@ void AIUpdateInterface::privateExitInstantly( Object *objectToExit, CommandSourc
 		// TheSuperHackers @bugfix Caball009 10/08/2026 Don't process invalid exit commands,
 		// because an object should not attempt to exit something it's not contained by.
 #if !RETAIL_COMPATIBLE_CRC
-		// @todo Remove function parameter 'objectToExit' because it's become obsolete.
-
 		if (us->getContainedBy() != objectToExit)
-			return;
+		{
+			const Player *unitPlayer = us->getControllingPlayer();
+			const Player *exitPlayer = objectToExit ? objectToExit->getControllingPlayer() : nullptr;
+			if (!unitPlayer || unitPlayer != exitPlayer
+				|| !isSharedNetworkExitContainer(us->getContainedBy(), objectToExit))
+				return;
+		}
 #endif
 	}
 

--- a/docs/WORKLOG/2026-08-DIARY.md
+++ b/docs/WORKLOG/2026-08-DIARY.md
@@ -1,5 +1,11 @@
 # August 2026
 
+## 15/08/2026
+### Fix Shared Tunnel and Cave Network Exits
+- Fixed passenger exit commands being rejected when a unit entered one tunnel or cave endpoint and was ordered out through another endpoint in the same player's shared network.
+- Kept strict rejection for unrelated containers, separate cave networks, and endpoints controlled by another player.
+- Applied the shared gameplay fix to Zero Hour and Generals.
+
 ## 14/08/2026
 ### Restore Windows LAN Map Compatibility
 - Kept spaces literal when serializing map names so TheSuperHackers Windows builds can resolve official maps such as Twilight Flame.


### PR DESCRIPTION
## Description

Allow units stored in a shared tunnel or cave network to exit through another
endpoint controlled by the same player.

The non-retail containment guard required the requested exit object to be the
unit's exact `containedBy` object. Tunnel passengers are stored by the shared
network, so valid exit commands through a different tunnel returned before
containment logic could process them.

## Changes

- recognize tunnel and cave containment capabilities
- permit exits between same-player endpoints of the same shared container type
- continue rejecting unrelated containers and enemy-controlled endpoints
- apply the fix to Zero Hour and Generals

## Validation

- built Zero Hour and Generals successfully with the macOS Vulkan preset
- traced the shared input path through the inventory control bar and game-logic
  dispatch to both containment exit functions
- verified the guard remains strict for ordinary non-network containers
