### PR TITLE
fix(compat): terminate itoa output reliably

### DIFF
--- a/GeneralsMD/Code/CompatLib/Source/string_compat.cpp
+++ b/GeneralsMD/Code/CompatLib/Source/string_compat.cpp
@@ -1,16 +1,44 @@
 #include "string_compat.h"
 
-#include <sstream>
-#include <streambuf>
-#include <ostream>
+#include <cctype>
+#include <cwchar>
+#include <string>
 
 char* itoa(int value, char* str, int base)
 {
-  // Create stringbuf from str
-  std::stringbuf buf;
-  buf.pubsetbuf(str, 33);
-  std::ostream os(&buf);
-  os << value << '\0';
+  if (base < 2 || base > 36)
+  {
+    str[0] = '\0';
+    return str;
+  }
+
+  static const char digits[] = "0123456789abcdefghijklmnopqrstuvwxyz";
+  const bool is_negative = value < 0 && base == 10;
+  unsigned int magnitude = static_cast<unsigned int>(value);
+  if (is_negative)
+  {
+    magnitude = 0U - magnitude;
+  }
+
+  char* output = str;
+  do
+  {
+    *output++ = digits[magnitude % static_cast<unsigned int>(base)];
+    magnitude /= static_cast<unsigned int>(base);
+  } while (magnitude != 0);
+
+  if (is_negative)
+  {
+    *output++ = '-';
+  }
+  *output = '\0';
+
+  for (char* left = str, *right = output - 1; left < right; ++left, --right)
+  {
+    const char temp = *left;
+    *left = *right;
+    *right = temp;
+  }
   return str;
 }
 

--- a/GeneralsMD/Code/CompatLib/Source/string_compat.cpp
+++ b/GeneralsMD/Code/CompatLib/Source/string_compat.cpp
@@ -1,16 +1,45 @@
 #include "string_compat.h"
 
-#include <sstream>
-#include <streambuf>
-#include <ostream>
+#include <cctype>
+#include <cwchar>
+#include <string>
 
+// GeneralsX @bugfix Copilot 26/08/2026 Provide portable null-terminated integer conversion.
 char* itoa(int value, char* str, int base)
 {
-  // Create stringbuf from str
-  std::stringbuf buf;
-  buf.pubsetbuf(str, 33);
-  std::ostream os(&buf);
-  os << value << '\0';
+  if (base < 2 || base > 36)
+  {
+    str[0] = '\0';
+    return str;
+  }
+
+  static const char digits[] = "0123456789abcdefghijklmnopqrstuvwxyz";
+  const bool is_negative = value < 0 && base == 10;
+  unsigned int magnitude = static_cast<unsigned int>(value);
+  if (is_negative)
+  {
+    magnitude = 0U - magnitude;
+  }
+
+  char* output = str;
+  do
+  {
+    *output++ = digits[magnitude % static_cast<unsigned int>(base)];
+    magnitude /= static_cast<unsigned int>(base);
+  } while (magnitude != 0);
+
+  if (is_negative)
+  {
+    *output++ = '-';
+  }
+  *output = '\0';
+
+  for (char* left = str, *right = output - 1; left < right; ++left, --right)
+  {
+    const char temp = *left;
+    *left = *right;
+    *right = temp;
+  }
   return str;
 }
 

--- a/docs/WORKLOG/2026-08-DIARY.md
+++ b/docs/WORKLOG/2026-08-DIARY.md
@@ -3,6 +3,10 @@
 > [!NOTE]
 > **AI-Generated Content Disclosure**: This worklog is automatically generated and maintained by AI coding agents to document daily progress, debugging sessions, and technical decisions.
 
+## 26/08/2026
+### Make Unix `itoa` Output Portable
+- Added the required compatibility-change annotation to the direct, null-terminated `itoa` conversion.
+
 ## 24/08/2026
 ### Preserve Control Bar Card Aspect Ratios on Widescreen Displays
 - Rescaled command buttons, selected-unit cameos, upgrade icons, and production queue buttons uniformly on displays wider than 4:3.


### PR DESCRIPTION
## Summary
- replace the Unix `itoa` implementation's non-portable `std::stringbuf::pubsetbuf` use with direct conversion
- preserve base 2-36 conversion and signed decimal behavior, including `INT_MIN`
- guarantee that the caller's output buffer is populated and null-terminated

## Multiplayer impact
The previous libc++ implementation did not reliably write into the caller-provided buffer. Multi-exit transports therefore built corrupted logical bone names such as `ExitStart0...`, fell back to the transport position, and desynchronized macOS from Windows while unloading passengers.

With this change, replaying the reported Infantry General Troop Crawler unload changes the macOS frame-7400 CRC from `9C0ABBE5` to the exact Windows CRC `F9A12D0B`.

## Validation
- built `GeneralsX` and `GeneralsXZH` with the `macos-vulkan` preset
- verified decimal, negative, `INT_MIN`, hexadecimal, and invalid-base conversions
- replayed the captured mixed-platform match through frame 7400


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved integer-to-string conversion reliability.
  - Added support for bases 2–36, returning an empty result for invalid bases.
  - Correctly handles negative decimal numbers.
  - Ensures converted strings are properly terminated and use lowercase letters for digit values.
- **Documentation**
  - Added a worklog entry documenting the compatibility improvement to integer conversion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->