### PR TITLE
fix(water): stabilize shoreline track alpha

### DIFF
--- a/Core/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWaterTracks.cpp
+++ b/Core/GameEngineDevice/Source/W3DDevice/GameClient/Water/W3DWaterTracks.cpp
@@ -911,6 +911,9 @@ Try improving the fit to vertical surfaces like cliffs.
 		DX8Wrapper::Set_DX8_Texture_Stage_State( 1, D3DTSS_COLORARG1, D3DTA_TEXTURE );	//stage 1 texture
 		DX8Wrapper::Set_DX8_Texture_Stage_State( 1, D3DTSS_COLORARG2, D3DTA_CURRENT );	//previous stage texture
 		DX8Wrapper::Set_DX8_Texture_Stage_State( 1, D3DTSS_COLOROP,   D3DTOP_MODULATE );
+		// GeneralsX @bugfix Copilot 24/08/2026 Keep shoreline alpha independent of stale texture-stage state.
+		DX8Wrapper::Set_DX8_Texture_Stage_State( 1, D3DTSS_ALPHAARG1, D3DTA_TEXTURE );
+		DX8Wrapper::Set_DX8_Texture_Stage_State( 1, D3DTSS_ALPHAARG2, D3DTA_CURRENT );
 		DX8Wrapper::Set_DX8_Texture_Stage_State( 1, D3DTSS_ALPHAOP,   D3DTOP_MODULATE );
 
 		//Shroud shader uses z-compare of EQUAL which wouldn't work on water because it doesn't
@@ -940,6 +943,9 @@ Try improving the fit to vertical surfaces like cliffs.
 	{	//we used the shroud shader, so reset it.
 		DX8Wrapper::Set_DX8_Render_State(D3DRS_ZFUNC, D3DCMP_EQUAL);
 		W3DShaderManager::resetShader(W3DShaderManager::ST_SHROUD_TEXTURE);
+		// GeneralsX @bugfix Copilot 26/08/2026 Restore the single-pass shader's stage-1 defaults.
+		DX8Wrapper::Set_DX8_Texture_Stage_State( 1, D3DTSS_COLOROP, D3DTOP_DISABLE );
+		DX8Wrapper::Set_DX8_Texture_Stage_State( 1, D3DTSS_ALPHAOP, D3DTOP_DISABLE );
 	}
 }
 

--- a/docs/WORKLOG/2026-08-DIARY.md
+++ b/docs/WORKLOG/2026-08-DIARY.md
@@ -4,6 +4,12 @@
 > **AI-Generated Content Disclosure**: This worklog is automatically generated and maintained by AI coding agents to document daily progress, debugging sessions, and technical decisions.
 
 ## 24/08/2026
+### Stabilize Shrouded Shoreline Alpha
+- Traced shadow volume/decal projection, terrain LOD/filtering, water shoreline blend/depth, lightmap, and particle render paths.
+- Fixed soft-water shoreline tracks to explicitly modulate their alpha with the shroud texture instead of inheriting stale texture-stage alpha arguments.
+- Restored the pass's stage-1 color and alpha operations after rendering so its local shroud modulation cannot affect the next draw.
+- Kept the change in the shared renderer so Generals and Zero Hour use identical rendering behavior without affecting simulation or effect timing.
+
 ### Preserve Control Bar Card Aspect Ratios on Widescreen Displays
 - Rescaled command buttons, selected-unit cameos, upgrade icons, and production queue buttons uniformly on displays wider than 4:3.
 - Extended the same correction to special-power shortcut card backgrounds, button hit regions, and overlays.


### PR DESCRIPTION
## Summary

- Set the shoreline-track texture stage's alpha arguments explicitly.
- Modulate shoreline texture alpha with the current shroud alpha.
- Prevent stale texture-stage state from producing inconsistent transparency.

The shared renderer change applies to both Generals and Zero Hour and does not alter water simulation, pathfinding, particle behavior, or gameplay state.

## Validation

- Passed focused texture-stage alpha-state checks.
- Built full Generals and Zero Hour macOS ARM64 targets.
- Applied the same reviewed change to the replay-compatible deterministic branch and completed all 7,535 frames of a multiplayer replay without a synchronization mismatch.

## AI assistance

GitHub Copilot assisted with tracing the texture-stage state and drafting the focused fix. I reviewed the diff, built both games, and replay-tested the exact local candidate before submission.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved soft-water shoreline track rendering by ensuring shroud textures correctly influence transparency.
  * Prevented inconsistent shoreline effects caused by stale rendering state.
  * Corrected control-bar card aspect ratios in widescreen layouts.

* **Documentation**
  * Added a worklog entry covering shoreline rendering improvements, widescreen layout corrections, and validation results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->