### PR TITLE
fix(graphics): preserve texture and render quality

### DIFF
--- a/Core/Libraries/Source/WWVegas/WW3D2/bitmaphandler.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/bitmaphandler.cpp
@@ -68,6 +68,37 @@ void BitmapHandlerClass::Copy_Image_Generate_Mipmap(
 		dest_pitch/=4;
 		src_pitch/=4;
 		mip_pitch/=4;
+		// GeneralsX @bugfix Copilot 24/08/2026 Box-filter one-dimensional mip tails instead of leaving rectangular texture levels uninitialized.
+		if (width==1) {
+			for (unsigned y=0;y<height/2;++y) {
+				unsigned* dest_ptr=(unsigned*)dest_surface+y*2*dest_pitch;
+				unsigned* src_ptr=(unsigned*)src_surface+y*2*src_pitch;
+				unsigned* mip_ptr=(unsigned*)mip_surface+y*mip_pitch;
+				unsigned col0=src_ptr[0];
+				unsigned col1=src_ptr[src_pitch];
+				dest_ptr[0]=col0;
+				dest_ptr[dest_pitch]=col1;
+				unsigned combined=Combine_A8R8G8B8(col0,col0,col1,col1);
+				if (has_hsv_shift) Recolor(combined,hsv_shift);
+				mip_ptr[0]=combined;
+			}
+			return;
+		}
+		if (height==1) {
+			unsigned* dest_ptr=(unsigned*)dest_surface;
+			unsigned* src_ptr=(unsigned*)src_surface;
+			unsigned* mip_ptr=(unsigned*)mip_surface;
+			for (unsigned x=0;x<width/2;++x) {
+				unsigned col0=*src_ptr++;
+				unsigned col1=*src_ptr++;
+				*dest_ptr++=col0;
+				*dest_ptr++=col1;
+				unsigned combined=Combine_A8R8G8B8(col0,col1,col0,col1);
+				if (has_hsv_shift) Recolor(combined,hsv_shift);
+				*mip_ptr++=combined;
+			}
+			return;
+		}
 		for (unsigned y=0;y<height/2;++y) {
 			unsigned* dest_ptr=(unsigned*)dest_surface;
 			dest_ptr+=2*y*dest_pitch;
@@ -103,6 +134,42 @@ void BitmapHandlerClass::Copy_Image_Generate_Mipmap(
 	WWASSERT(src_format!=WW3D_FORMAT_P8);		// This function doesn't support paletted formats
 	unsigned src_bpp=Get_Bytes_Per_Pixel(src_format);
 	unsigned dest_bpp=Get_Bytes_Per_Pixel(dest_format);
+
+	// GeneralsX @bugfix Copilot 24/08/2026 Preserve format conversion and box filtering for one-dimensional mip tails.
+	if (width==1) {
+		for (unsigned y=0;y<height/2;++y) {
+			unsigned char* dest_ptr=dest_surface+y*2*dest_pitch;
+			unsigned char* src_ptr=src_surface+y*2*src_pitch;
+			unsigned char* mip_ptr=mip_surface+y*mip_pitch;
+			unsigned col0;
+			unsigned col1;
+			Read_B8G8R8A8(col0,src_ptr,src_format,nullptr,0);
+			Read_B8G8R8A8(col1,src_ptr+src_pitch,src_format,nullptr,0);
+			Write_B8G8R8A8(dest_ptr,dest_format,col0);
+			Write_B8G8R8A8(dest_ptr+dest_pitch,dest_format,col1);
+			unsigned combined=Combine_A8R8G8B8(col0,col0,col1,col1);
+			if (has_hsv_shift) Recolor(combined,hsv_shift);
+			Write_B8G8R8A8(mip_ptr,dest_format,combined);
+		}
+		return;
+	}
+	if (height==1) {
+		unsigned char* dest_ptr=dest_surface;
+		unsigned char* src_ptr=src_surface;
+		unsigned char* mip_ptr=mip_surface;
+		for (unsigned x=0;x<width/2;++x,dest_ptr+=dest_bpp*2,src_ptr+=src_bpp*2,mip_ptr+=dest_bpp) {
+			unsigned col0;
+			unsigned col1;
+			Read_B8G8R8A8(col0,src_ptr,src_format,nullptr,0);
+			Read_B8G8R8A8(col1,src_ptr+src_bpp,src_format,nullptr,0);
+			Write_B8G8R8A8(dest_ptr,dest_format,col0);
+			Write_B8G8R8A8(dest_ptr+dest_bpp,dest_format,col1);
+			unsigned combined=Combine_A8R8G8B8(col0,col1,col0,col1);
+			if (has_hsv_shift) Recolor(combined,hsv_shift);
+			Write_B8G8R8A8(mip_ptr,dest_format,combined);
+		}
+		return;
+	}
 
 	for (unsigned y=0;y<height/2;++y) {
 		unsigned char* dest_ptr=dest_surface+2*y*dest_pitch;
@@ -264,9 +331,44 @@ void BitmapHandlerClass::Copy_Image(
 			// Generate the next mip level while copying the current surface?
 			if (generate_mip_level) {
 				if (dest_surface_width==1) {
-					unsigned b8g8r8a8=*(unsigned*)src_surface;
-					if (has_hsv_shift) Recolor(b8g8r8a8,hsv_shift);
-					*(unsigned*)dest_surface=b8g8r8a8;
+					unsigned* dest_ptr=(unsigned*)dest_surface;
+					unsigned* src_ptr=(unsigned*)src_surface;
+					if (dest_surface_height==1) {
+						unsigned b8g8r8a8=*src_ptr;
+						if (has_hsv_shift) Recolor(b8g8r8a8,hsv_shift);
+						*dest_ptr=b8g8r8a8;
+					}
+					else {
+						// GeneralsX @bugfix Copilot 24/08/2026 Generate vertical one-dimensional mip tails with the same box filter as two-dimensional levels.
+						for (unsigned y=0;y<dest_surface_height/2;++y) {
+							unsigned col0=src_ptr[y*2*src_surface_pitch];
+							unsigned col1=src_ptr[(y*2+1)*src_surface_pitch];
+							if (has_hsv_shift) {
+								Recolor(col0,hsv_shift);
+								Recolor(col1,hsv_shift);
+							}
+							dest_ptr[y*2*dest_surface_pitch]=col0;
+							dest_ptr[(y*2+1)*dest_surface_pitch]=col1;
+							src_ptr[y*src_surface_pitch]=Combine_A8R8G8B8(col0,col0,col1,col1);
+						}
+					}
+				}
+				else if (dest_surface_height==1) {
+					// GeneralsX @bugfix Copilot 24/08/2026 Generate horizontal one-dimensional mip tails with the same box filter as two-dimensional levels.
+					unsigned* dest_ptr=(unsigned*)dest_surface;
+					unsigned* src_ptr=(unsigned*)src_surface;
+					unsigned* mip_ptr=(unsigned*)src_surface;
+					for (unsigned x=0;x<dest_surface_width/2;++x) {
+						unsigned col0=*src_ptr++;
+						unsigned col1=*src_ptr++;
+						if (has_hsv_shift) {
+							Recolor(col0,hsv_shift);
+							Recolor(col1,hsv_shift);
+						}
+						*dest_ptr++=col0;
+						*dest_ptr++=col1;
+						*mip_ptr++=Combine_A8R8G8B8(col0,col1,col0,col1);
+					}
 				}
 				else {
 					for (unsigned y=0;y<dest_surface_height/2;++y) {
@@ -359,14 +461,50 @@ void BitmapHandlerClass::Copy_Image(
 		if (generate_mip_level) {
 			WWASSERT(src_surface_format!=WW3D_FORMAT_P8);	// Paletted textures can't be mipmapped
 			if (dest_surface_width==1) {
+				if (dest_surface_height==1) {
+					unsigned b8g8r8a8;
+					Read_B8G8R8A8(b8g8r8a8,src_surface,src_surface_format,src_palette,src_palette_bpp);
+					if (has_hsv_shift) Recolor(b8g8r8a8,hsv_shift);
+					Write_B8G8R8A8(dest_surface,dest_surface_format,b8g8r8a8);
+				}
+				else {
+					// GeneralsX @bugfix Copilot 24/08/2026 Generate converted vertical one-dimensional mip tails without skipping their pixels.
+					for (unsigned y=0;y<dest_surface_height/2;++y) {
+						unsigned char* dest_ptr=dest_surface+y*2*dest_surface_pitch;
+						unsigned char* src_ptr=src_surface+y*2*src_surface_pitch;
+						unsigned char* mip_ptr=src_surface+y*src_surface_pitch;
+						unsigned col0;
+						unsigned col1;
+						Read_B8G8R8A8(col0,src_ptr,src_surface_format,src_palette,src_palette_bpp);
+						Read_B8G8R8A8(col1,src_ptr+src_surface_pitch,src_surface_format,src_palette,src_palette_bpp);
+						if (has_hsv_shift) {
+							Recolor(col0,hsv_shift);
+							Recolor(col1,hsv_shift);
+						}
+						Write_B8G8R8A8(dest_ptr,dest_surface_format,col0);
+						Write_B8G8R8A8(dest_ptr+dest_surface_pitch,dest_surface_format,col1);
+						Write_B8G8R8A8(mip_ptr,src_surface_format,Combine_A8R8G8B8(col0,col0,col1,col1));
+					}
+				}
+			}
+			else if (dest_surface_height==1) {
+				// GeneralsX @bugfix Copilot 24/08/2026 Generate converted horizontal one-dimensional mip tails without skipping their pixels.
 				unsigned char* dest_ptr=dest_surface;
 				unsigned char* src_ptr=src_surface;
-				unsigned b8g8r8a8;
-				Read_B8G8R8A8(b8g8r8a8,src_ptr,src_surface_format,src_palette,src_palette_bpp);
-				if (has_hsv_shift) {
-					Recolor(b8g8r8a8,hsv_shift);
+				unsigned char* mip_ptr=src_surface;
+				for (unsigned x=0;x<dest_surface_width/2;x++,dest_ptr+=dest_bpp*2,src_ptr+=src_bpp*2,mip_ptr+=src_bpp) {
+					unsigned col0;
+					unsigned col1;
+					Read_B8G8R8A8(col0,src_ptr,src_surface_format,src_palette,src_palette_bpp);
+					Read_B8G8R8A8(col1,src_ptr+src_bpp,src_surface_format,src_palette,src_palette_bpp);
+					if (has_hsv_shift) {
+						Recolor(col0,hsv_shift);
+						Recolor(col1,hsv_shift);
+					}
+					Write_B8G8R8A8(dest_ptr,dest_surface_format,col0);
+					Write_B8G8R8A8(dest_ptr+dest_bpp,dest_surface_format,col1);
+					Write_B8G8R8A8(mip_ptr,src_surface_format,Combine_A8R8G8B8(col0,col1,col0,col1));
 				}
-				Write_B8G8R8A8(dest_ptr,dest_surface_format,b8g8r8a8);
 			}
 			else {
 				for (unsigned y=0;y<dest_surface_height/2;++y) {

--- a/Core/Libraries/Source/WWVegas/WW3D2/dx8renderer.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/dx8renderer.cpp
@@ -1361,12 +1361,12 @@ void DX8SkinFVFCategoryContainer::Render()
 					verts[v].nx=(*norm)[0];
 					verts[v].ny=(*norm)[1];
 					verts[v].nz=(*norm)[2];
-					// Force diffuse to white (0xFFFFFFFF) because Base Game infantry 
-					// often have black vertex colors baked into their W3D files
-					// which causes them to render completely black in DXVK when D3DTA_DIFFUSE is used.
-					verts[v].diffuse=0xFFFFFFFF;
+					// GeneralsX @bugfix Copilot 24/08/2026 Preserve authored skin colors and use white only when no color array exists.
 					if (diffuse) {
-						diffuse++; // Advance the pointer if it exists, to keep it in sync if needed (though we only use it here)
+						verts[v].diffuse=*diffuse++;
+					}
+					else {
+						verts[v].diffuse=0xFFFFFFFF;
 					}
 
 					if (uv0) {
@@ -1406,16 +1406,6 @@ void DX8SkinFVFCategoryContainer::Render()
 		DX8Wrapper::Set_Index_Buffer(index_buffer,0);
 
 		//Flush the meshes which fit in the vertex buffer, applying all texture variations
-		// GeneralsX @bugfix fbraz3 19/06/2026 Force COLOR1 diffuse source and disable D3D lighting for skins.
-		// Skinned mesh verts have diffuse=0xFFFFFFFF baked in (see vertex fill loop above).
-		// With D3DRS_LIGHTING=TRUE and D3DMCS_MATERIAL, DXVK's lighting equation produces black
-		// when no LightEnvironment is set. Forcing COLOR1 makes D3DTA_DIFFUSE=vertex.diffuse=white,
-		// so MODULATE(texture, white)=texture - matching original VC6/D3D8 behavior.
-		DX8Wrapper::Apply_Render_State_Changes();
-		DX8Wrapper::Set_DX8_Render_State(D3DRS_DIFFUSEMATERIALSOURCE, D3DMCS_COLOR1);
-		DX8Wrapper::Set_DX8_Render_State(D3DRS_AMBIENTMATERIALSOURCE, D3DMCS_COLOR1);
-		DX8Wrapper::Set_DX8_Render_State(D3DRS_LIGHTING, FALSE);
-
 		for (unsigned pass=0;pass<passes;++pass) {
 			SNAPSHOT_SAY(("Pass: %d",pass));
 
@@ -1425,10 +1415,6 @@ void DX8SkinFVFCategoryContainer::Render()
 				it.Next();
 			}
 		}
-
-		// Restore render states to defaults after skin render
-		DX8Wrapper::Set_DX8_Render_State(D3DRS_DIFFUSEMATERIALSOURCE, D3DMCS_MATERIAL);
-		DX8Wrapper::Set_DX8_Render_State(D3DRS_AMBIENTMATERIALSOURCE, D3DMCS_MATERIAL);
 
 		Render_Procedural_Material_Passes();
 	}
@@ -2294,7 +2280,6 @@ void DX8MeshRendererClass::Invalidate( bool shutdown)
 
 	texture_category_container_lists_rigid.Delete_All();
 }
-
 
 
 

--- a/Core/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
@@ -106,6 +106,58 @@ const D3DMULTISAMPLE_TYPE DEFAULT_MSAA = D3DMULTISAMPLE_NONE;
 
 static D3DPRESENT_PARAMETERS _PresentParameters;
 
+// GeneralsX @bugfix Copilot 24/08/2026 Fall back through supported MSAA sample counts instead of disabling AA immediately.
+static D3DMULTISAMPLE_TYPE Normalize_MSAA_Mode(D3DMULTISAMPLE_TYPE mode)
+{
+	if (mode >= D3DMULTISAMPLE_8_SAMPLES)
+		return D3DMULTISAMPLE_8_SAMPLES;
+	if (mode >= D3DMULTISAMPLE_4_SAMPLES)
+		return D3DMULTISAMPLE_4_SAMPLES;
+	if (mode >= D3DMULTISAMPLE_2_SAMPLES)
+		return D3DMULTISAMPLE_2_SAMPLES;
+
+	return D3DMULTISAMPLE_NONE;
+}
+
+static D3DMULTISAMPLE_TYPE Get_Lower_MSAA_Mode(D3DMULTISAMPLE_TYPE mode)
+{
+	switch (mode)
+	{
+	case D3DMULTISAMPLE_8_SAMPLES:
+		return D3DMULTISAMPLE_4_SAMPLES;
+	case D3DMULTISAMPLE_4_SAMPLES:
+		return D3DMULTISAMPLE_2_SAMPLES;
+	case D3DMULTISAMPLE_2_SAMPLES:
+	default:
+		return D3DMULTISAMPLE_NONE;
+	}
+}
+
+static bool Is_MSAA_Mode_Supported(
+	IDirect3D8 *direct3D,
+	unsigned adapter,
+	D3DFORMAT backBufferFormat,
+	D3DFORMAT depthStencilFormat,
+	BOOL windowed,
+	D3DMULTISAMPLE_TYPE mode)
+{
+	if (mode == D3DMULTISAMPLE_NONE)
+		return true;
+
+	return SUCCEEDED(direct3D->CheckDeviceMultiSampleType(
+		adapter,
+		D3DDEVTYPE_HAL,
+		backBufferFormat,
+		windowed,
+		mode)) &&
+		SUCCEEDED(direct3D->CheckDeviceMultiSampleType(
+			adapter,
+			D3DDEVTYPE_HAL,
+			depthStencilFormat,
+			windowed,
+			mode));
+}
+
 // --- Pillarbox: render game to offscreen RT, blit centered onto backbuffer ---
 // GeneralsX @feature xxorza 15/04/2026 Unified pillarbox for fullscreen and windowed
 DX8Wrapper::DisplaySizeFunc DX8Wrapper::s_getNativeDisplaySize = nullptr;
@@ -1414,28 +1466,24 @@ bool DX8Wrapper::Set_Render_Device(int dev, int width, int height, int bits, int
 	** Check the devices support for the requested MSAA mode then setup the multi sample type
 	*/
 	if (MultiSampleAntiAliasing > D3DMULTISAMPLE_NONE) {
+		const D3DMULTISAMPLE_TYPE requestedMode = MultiSampleAntiAliasing;
+		MultiSampleAntiAliasing = Normalize_MSAA_Mode(MultiSampleAntiAliasing);
 
-		HRESULT hrBack = D3DInterface->CheckDeviceMultiSampleType(
+		while (!Is_MSAA_Mode_Supported(
+			D3DInterface,
 			CurRenderDevice,
-			D3DDEVTYPE_HAL,
 			_PresentParameters.BackBufferFormat,
-			IsWindowed,
-			MultiSampleAntiAliasing
-		);
-
-		HRESULT hrDepth = D3DInterface->CheckDeviceMultiSampleType(
-			CurRenderDevice,
-			D3DDEVTYPE_HAL,
 			_PresentParameters.AutoDepthStencilFormat,
 			IsWindowed,
-			MultiSampleAntiAliasing
-		);
+			MultiSampleAntiAliasing))
+		{
+			MultiSampleAntiAliasing = Get_Lower_MSAA_Mode(MultiSampleAntiAliasing);
+		}
 
-		if (FAILED(hrBack) || FAILED(hrDepth)) {
-			// IF we fail then disable MSAA entirely.
-			// External code needs to retrieve the configured MSAA mode after device creation
-			WWDEBUG_SAY(("Requested MSAA Mode Not Supported"));
-			MultiSampleAntiAliasing = D3DMULTISAMPLE_NONE;
+		if (MultiSampleAntiAliasing != requestedMode) {
+			WWDEBUG_SAY(("Requested MSAA mode %u is unsupported; using %u",
+				(unsigned)requestedMode,
+				(unsigned)MultiSampleAntiAliasing));
 		}
 	}
 

--- a/Core/Libraries/Source/WWVegas/WW3D2/texture.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/texture.cpp
@@ -70,6 +70,15 @@ static unsigned unused_texture_id;
 static unsigned TexturesAppliedPerFrame;
 const unsigned MAX_TEXTURES_APPLIED_PER_FRAME=2;
 
+// GeneralsX @bugfix Copilot 24/08/2026 Preserve explicit mip requests while resolving all-level requests from authored metadata.
+static MipCountType Resolve_Mip_Level_Count(MipCountType requested, unsigned authored)
+{
+	if (requested==MIP_LEVELS_ALL || (requested!=MIP_LEVELS_1 && (unsigned)requested>authored))
+		return (MipCountType)authored;
+
+	return requested;
+}
+
 
 /*!
  * KM General base constructor for texture classes
@@ -732,9 +741,9 @@ TextureClass::TextureClass
 	{
 		Width=thumb->Get_Original_Texture_Width();
 		Height=thumb->Get_Original_Texture_Height();
- 		if (MipLevelCount!=MIP_LEVELS_1) {
- 			MipLevelCount=(MipCountType)thumb->Get_Original_Texture_Mip_Level_Count();
- 		}
+		MipLevelCount=Resolve_Mip_Level_Count(
+			MipLevelCount,
+			thumb->Get_Original_Texture_Mip_Level_Count());
 	}
 
 	LastAccessed=WW3D::Get_Sync_Time();
@@ -1477,9 +1486,9 @@ CubeTextureClass::CubeTextureClass
 	{
 		Width=thumb->Get_Original_Texture_Width();
 		Height=thumb->Get_Original_Texture_Height();
- 		if (MipLevelCount!=MIP_LEVELS_1) {
- 			MipLevelCount=(MipCountType)thumb->Get_Original_Texture_Mip_Level_Count();
- 		}
+		MipLevelCount=Resolve_Mip_Level_Count(
+			MipLevelCount,
+			thumb->Get_Original_Texture_Mip_Level_Count());
 	}
 
 	LastAccessed=WW3D::Get_Sync_Time();
@@ -1762,9 +1771,9 @@ VolumeTextureClass::VolumeTextureClass
 	{
 		Width=thumb->Get_Original_Texture_Width();
 		Height=thumb->Get_Original_Texture_Height();
- 		if (MipLevelCount!=MIP_LEVELS_1) {
- 			MipLevelCount=(MipCountType)thumb->Get_Original_Texture_Mip_Level_Count();
- 		}
+		MipLevelCount=Resolve_Mip_Level_Count(
+			MipLevelCount,
+			thumb->Get_Original_Texture_Mip_Level_Count());
 	}
 
 	LastAccessed=WW3D::Get_Sync_Time();

--- a/Core/Libraries/Source/WWVegas/WW3D2/texturefilter.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/texturefilter.cpp
@@ -213,7 +213,8 @@ void TextureFilterClass::_Init_Filters(TextureFilterMode texture_filter, Anisotr
 	case TEXTURE_FILTER_ANISOTROPIC:
 
 		FilterSupported = (dx8caps.TextureFilterCaps & D3DPTFILTERCAPS_MAGFANISOTROPIC) &&
-			(dx8caps.TextureFilterCaps & D3DPTFILTERCAPS_MINFANISOTROPIC);
+			(dx8caps.TextureFilterCaps & D3DPTFILTERCAPS_MINFANISOTROPIC) &&
+			dx8caps.MaxAnisotropy > 1;
 
 		if (FilterSupported) {
 			_MinTextureFilters[0][FILTER_TYPE_BEST]=D3DTEXF_ANISOTROPIC;
@@ -223,8 +224,12 @@ void TextureFilterClass::_Init_Filters(TextureFilterMode texture_filter, Anisotr
 			_Set_Max_Anisotropy(anisotropy_level);
 		}
 		else {
-			_MinTextureFilters[0][FILTER_TYPE_BEST]=D3DTEXF_POINT;
-			_MagTextureFilters[0][FILTER_TYPE_BEST]=D3DTEXF_POINT;
+			// GeneralsX @bugfix Copilot 24/08/2026 Fall back to linear filtering when anisotropy is unavailable.
+			const BOOL linearFilterSupported =
+				(dx8caps.TextureFilterCaps & D3DPTFILTERCAPS_MINFLINEAR) &&
+				(dx8caps.TextureFilterCaps & D3DPTFILTERCAPS_MAGFLINEAR);
+			_MinTextureFilters[0][FILTER_TYPE_BEST]=linearFilterSupported ? D3DTEXF_LINEAR : D3DTEXF_POINT;
+			_MagTextureFilters[0][FILTER_TYPE_BEST]=linearFilterSupported ? D3DTEXF_LINEAR : D3DTEXF_POINT;
 		}
 
 		if (dx8caps.TextureFilterCaps & D3DPTFILTERCAPS_MIPFLINEAR) {
@@ -295,10 +300,23 @@ void TextureFilterClass::Set_Mip_Mapping(FilterType mipmap)
 //! Set anisotropic filter level
 /*!
 */
-void TextureFilterClass::_Set_Max_Anisotropy(AnisotropicFilterMode mode)
+// GeneralsX @bugfix Copilot 24/08/2026 Clamp anisotropy to the active renderer capability.
+int TextureFilterClass::_Set_Max_Anisotropy(int level)
 {
+	const D3DCAPS8& dx8caps=DX8Wrapper::Get_Current_Caps()->Get_DX8_Caps();
+	const bool anisotropySupported =
+		(dx8caps.TextureFilterCaps & D3DPTFILTERCAPS_MAGFANISOTROPIC) &&
+		(dx8caps.TextureFilterCaps & D3DPTFILTERCAPS_MINFANISOTROPIC) &&
+		dx8caps.MaxAnisotropy > 1;
+	unsigned anisotropy=anisotropySupported ? (unsigned)level : 1;
+
+	if (anisotropy < 1) anisotropy=1;
+	if (anisotropySupported && anisotropy > dx8caps.MaxAnisotropy) anisotropy=dx8caps.MaxAnisotropy;
+
 	for (int stage = 0; stage < MAX_TEXTURE_STAGES; ++stage)
-		DX8Wrapper::Set_DX8_Texture_Stage_State(stage, D3DTSS_MAXANISOTROPY, mode);
+		DX8Wrapper::Set_DX8_Texture_Stage_State(stage, D3DTSS_MAXANISOTROPY, anisotropy);
+
+	return (int)anisotropy;
 }
 
 //**********************************************************************************************

--- a/Core/Libraries/Source/WWVegas/WW3D2/texturefilter.h
+++ b/Core/Libraries/Source/WWVegas/WW3D2/texturefilter.h
@@ -130,7 +130,8 @@ public:
 
 	// These need to be called after device has been created
 	static void _Init_Filters(TextureFilterMode texture_filter, AnisotropicFilterMode anisotropy_level);
-	static void _Set_Max_Anisotropy(AnisotropicFilterMode mode);
+	// GeneralsX @bugfix Copilot 24/08/2026 Return the capability-limited anisotropy level applied to the renderer.
+	static int _Set_Max_Anisotropy(int level);
 
 	static void _Set_Default_Min_Filter(FilterType filter);
 	static void _Set_Default_Mag_Filter(FilterType filter);

--- a/Core/Libraries/Source/WWVegas/WW3D2/textureloader.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/textureloader.cpp
@@ -508,10 +508,12 @@ IDirect3DTexture8* TextureLoader::Load_Thumbnail(const StringClass& filename, co
 		hsv=Vector3(0.0f,0.0f,0.0f);	// Only do the shift for the first level, as the mipmaps are based on it.
 
 		src_format=dest_format;
-		src_surface=(unsigned char*)locked_rects[level].pBits;
-		src_pitch=locked_rects[level].Pitch;
-		width>>=1;
-		height>>=1;
+		// GeneralsX @bugfix Copilot 24/08/2026 Build each thumbnail mip from the preceding box-filter result.
+		src_surface=(unsigned char*)locked_rects[level+1].pBits;
+		src_pitch=locked_rects[level+1].Pitch;
+		// GeneralsX @bugfix Copilot 24/08/2026 Keep rectangular mip dimensions at one texel while generating the remaining axis.
+		width=max(width>>1,1u);
+		height=max(height>>1,1u);
 	}
 
 	// Unlock all surfaces
@@ -1385,6 +1387,21 @@ static unsigned Get_Requested_Reduction(unsigned width, unsigned height, unsigne
 	return curReduction;
 }
 
+// GeneralsX @bugfix Copilot 24/08/2026 Count complete rectangular mip chains until both axes reach one texel.
+static unsigned Get_Full_Mip_Level_Count(unsigned width, unsigned height)
+{
+	unsigned mipCount=1;
+	unsigned mipWidth=1;
+	unsigned mipHeight=1;
+	while (mipWidth<width || mipHeight<height)
+	{
+		mipWidth<<=1;
+		mipHeight<<=1;
+		mipCount++;
+	}
+	return mipCount;
+}
+
 
 static bool	Get_Texture_Information
 (
@@ -1430,9 +1447,7 @@ static bool	Get_Texture_Information
 		Get_WW3D_Format(dest_format,format,bpp,targa);
 
 		// Figure out how many mip levels this texture will occupy
-		mip_count = 0;
-		for (int i=targa.Header.Width, j=targa.Header.Height; i > 0 && j > 0; i>>=1, j>>=1)
-				mip_count++;
+		mip_count=Get_Full_Mip_Level_Count(targa.Header.Width,targa.Header.Height);
 
 		// Destination size will be the next power of two square from the larger width and height...
 		w = targa.Header.Width;
@@ -1556,14 +1571,7 @@ static void Apply_Mip_Reduction(unsigned& mip_level_count, unsigned reduction, u
 
 	// Once more, verify that the mip level count is correct (in case it was changed here it might not
 	// match the size...well actually it doesn't have to match but it can't be bigger than the size)
-	unsigned int max_mip_level_count = 1;
-	unsigned int dim = MinTextureDim;
-
-	while (dim < width && dim < height)
-	{
-		dim <<= 1;
-		max_mip_level_count++;
-	}
+	unsigned int max_mip_level_count=Get_Full_Mip_Level_Count(width,height);
 
 	if (mip_level_count > max_mip_level_count)
 		mip_level_count = max_mip_level_count;
@@ -1897,10 +1905,10 @@ bool TextureLoadTaskClass::Load_Uncompressed_Mipmap()
 			true,
 			hsv_shift);
 
-			width			>>= 1;
-			height		>>= 1;
-			src_width	>>= 1;
-			src_height	>>= 1;
+			width=max(width>>1,1u);
+			height=max(height>>1,1u);
+			src_width=max(src_width>>1,1u);
+			src_height=max(src_height>>1,1u);
 		}
 		delete [] destination_surface;
 	}
@@ -1924,14 +1932,15 @@ bool TextureLoadTaskClass::Load_Uncompressed_Mipmap()
 			hsv_shift);
 		hsv_shift=Vector3(0.0f,0.0f,0.0f);
 
-		width			>>= 1;
-		height		>>= 1;
-		src_width	>>= 1;
-		src_height	>>= 1;
-
-		if (!width || !height || !src_width || !src_height) {
+		if (width==1 && height==1) {
 			break;
 		}
+
+		// GeneralsX @bugfix Copilot 24/08/2026 Continue generated rectangular mip chains along their remaining non-unit axis.
+		width=max(width>>1,1u);
+		height=max(height>>1,1u);
+		src_width=max(src_width>>1,1u);
+		src_height=max(src_height>>1,1u);
 	}
 
 	delete[] converted_surface;

--- a/Core/Libraries/Source/WWVegas/WW3D2/texturethumbnail.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/texturethumbnail.cpp
@@ -42,6 +42,43 @@ static void Create_Hash_Name(StringClass& name, const StringClass& thumb_name)
 	_strlwr(name.Peek_Buffer());
 }
 
+static bool Is_DDS_Thumbnail_Format_Supported(WW3DFormat format)
+{
+	return format==WW3D_FORMAT_DXT1 || format==WW3D_FORMAT_DXT5;
+}
+
+// GeneralsX @bugfix Copilot 24/08/2026 Downsample sparse DDS levels directly into bounded thumbnail storage.
+static void Copy_Scaled_DDS_Thumbnail(
+	const DDSFileClass& dds_file,
+	unsigned level,
+	unsigned width,
+	unsigned height,
+	unsigned char* bitmap)
+{
+	const unsigned source_width=dds_file.Get_Width(level);
+	const unsigned source_height=dds_file.Get_Height(level);
+	unsigned block[16]={0};
+
+	for (unsigned y=0;y<height;++y) {
+		const unsigned source_y=y*source_height/height;
+		for (unsigned x=0;x<width;++x) {
+			const unsigned source_x=x*source_width/width;
+			dds_file.Get_4x4_Block(
+				(unsigned char*)block,
+				sizeof(unsigned)*4,
+				WW3D_FORMAT_A8R8G8B8,
+				level,
+				source_x&~3u,
+				source_y&~3u);
+			const unsigned color=block[(source_y&3u)*4+(source_x&3u)];
+			BitmapHandlerClass::Write_B8G8R8A8(
+				bitmap+(y*width+x)*2,
+				WW3D_FORMAT_A4R4G4B4,
+				color);
+		}
+	}
+}
+
 	/*	file_auto_ptr my_tga_file(_TheFileFactory,filename);
 	if (my_tga_file->Is_Available()) {
 		my_tga_file->Open();
@@ -118,7 +155,10 @@ ThumbnailClass::ThumbnailClass(ThumbnailManagerClass* manager, const StringClass
 
 	// First, try loading image from a DDS file
 	DDSFileClass dds_file(filename,reduction_factor);
-	if (dds_file.Is_Available() && dds_file.Load()) {
+	// GeneralsX @bugfix Copilot 24/08/2026 Reject DDS formats without a complete block decoder so the TGA fallback remains initialized.
+	if (dds_file.Is_Available() &&
+		Is_DDS_Thumbnail_Format_Supported(dds_file.Get_Format()) &&
+		dds_file.Load()) {
 		DateTime=dds_file.Get_Date_Time();
 
 		int len=Name.Get_Length();
@@ -128,27 +168,39 @@ ThumbnailClass::ThumbnailClass(ThumbnailManagerClass* manager, const StringClass
 		Name[len-1]='s';
 
 		unsigned level=0;
-		while (dds_file.Get_Width(level)>32 || dds_file.Get_Height(level)>32) {
-			if (level>=dds_file.Get_Mip_Level_Count()) break;
+		const unsigned mip_level_count=dds_file.Get_Mip_Level_Count();
+		// GeneralsX @bugfix Copilot 24/08/2026 Check bounds before selecting the smallest authored thumbnail mip.
+		while (level+1<mip_level_count &&
+			(dds_file.Get_Width(level)>32 || dds_file.Get_Height(level)>32)) {
 			level++;
 		}
 
 		OriginalTextureWidth=dds_file.Get_Full_Width();
 		OriginalTextureHeight=dds_file.Get_Full_Height();
 		OriginalTextureFormat=dds_file.Get_Format();
-		OriginalTextureMipLevelCount=dds_file.Get_Mip_Level_Count();
-		Width=dds_file.Get_Width(0);
-		Height=dds_file.Get_Height(0);
+		// GeneralsX @bugfix Copilot 24/08/2026 Keep authored DDS mip metadata independent of thumbnail reduction.
+		OriginalTextureMipLevelCount=dds_file.Get_Full_Mip_Level_Count();
+		Width=dds_file.Get_Width(level);
+		Height=dds_file.Get_Height(level);
+		while (Width>32 || Height>32) {
+			Width=max(Width>>1,1u);
+			Height=max(Height>>1,1u);
+		}
 		Bitmap=W3DNEWARRAY unsigned char[Width*Height*2];
 		Allocated=true;
-		dds_file.Copy_Level_To_Surface(
-			0,			// Level
-			WW3D_FORMAT_A4R4G4B4,
-			Width,
-			Height,
-			Bitmap,
-			Width*2,
-			Vector3(0.0f,0.0f,0.0f));// We don't want to HSV-shift here
+		if (Width==dds_file.Get_Width(level) && Height==dds_file.Get_Height(level)) {
+			dds_file.Copy_Level_To_Surface(
+				level,
+				WW3D_FORMAT_A4R4G4B4,
+				Width,
+				Height,
+				Bitmap,
+				Width*2,
+				Vector3(0.0f,0.0f,0.0f));// We don't want to HSV-shift here
+		}
+		else {
+			Copy_Scaled_DDS_Thumbnail(dds_file,level,Width,Height,Bitmap);
+		}
 	}
 	// If DDS file can't be used try loading from TGA
 	else {
@@ -176,7 +228,8 @@ ThumbnailClass::ThumbnailClass(ThumbnailManagerClass* manager, const StringClass
 		OriginalTextureMipLevelCount=1;
 		unsigned iw=1;
 		unsigned ih=1;
-		while (iw<OriginalTextureWidth && ih<OriginalTextureHeight) {
+		// GeneralsX @bugfix Copilot 24/08/2026 Count rectangular TGA mip tails until both axes reach their power-of-two extent.
+		while (iw<OriginalTextureWidth || ih<OriginalTextureHeight) {
 			iw+=iw;
 			ih+=ih;
 			OriginalTextureMipLevelCount++;

--- a/Core/Libraries/Source/WWVegas/WW3D2/ww3d.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/ww3d.cpp
@@ -782,8 +782,12 @@ void WW3D::Set_Anisotropy_Level(int level)
 	level = clamp((int)TextureFilterClass::TEXTURE_FILTER_ANISOTROPIC_2X, level, (int)TextureFilterClass::TEXTURE_FILTER_ANISOTROPIC_16X);
 	level = highestBit(level);
 
-	AnisotropyLevel = level;
-	TextureFilterClass::_Set_Max_Anisotropy((TextureFilterClass::AnisotropicFilterMode)AnisotropyLevel);
+	// GeneralsX @bugfix Copilot 24/08/2026 Track the safe effective anisotropy without changing the saved request.
+	AnisotropyLevel = TextureFilterClass::_Set_Max_Anisotropy(level);
+	if (AnisotropyLevel != level)
+		WWDEBUG_SAY(("Requested anisotropy level %u is unsupported; using %u",
+			(unsigned)level,
+			(unsigned)AnisotropyLevel));
 }
 
 /***********************************************************************************************

--- a/Core/Libraries/Source/WWVegas/WW3D2/ww3dformat.cpp
+++ b/Core/Libraries/Source/WWVegas/WW3D2/ww3dformat.cpp
@@ -313,7 +313,8 @@ WW3DFormat Get_Valid_Texture_Format(WW3DFormat format, bool is_compression_allow
 		!current_caps->Support_DXTC() ||
 		!is_compression_allowed) {
 		switch (format) {
-		case WW3D_FORMAT_DXT1: format=WW3D_FORMAT_R8G8B8; break;
+		// GeneralsX @bugfix Copilot 24/08/2026 Preserve DXT1 one-bit alpha when compressed textures require an uncompressed fallback.
+		case WW3D_FORMAT_DXT1: format=WW3D_FORMAT_A8R8G8B8; break;
 		case WW3D_FORMAT_DXT2:
 		case WW3D_FORMAT_DXT3:
 		case WW3D_FORMAT_DXT4:

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/ddsfile.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/ddsfile.cpp
@@ -105,12 +105,9 @@ DDSFileClass::DDSFileClass(const char* name,unsigned reduction_factor)
 	MipLevels=SurfaceDesc.MipMapCount;
 	if (MipLevels==0) MipLevels=1;
 
-
-	if (MipLevels>ReductionFactor) MipLevels-=ReductionFactor;
-	else {
-		MipLevels=1;
-		ReductionFactor=ReductionFactor-MipLevels;
-	}
+	// GeneralsX @bugfix Copilot 24/08/2026 Clamp DDS reduction to authored levels so thumbnail loads cannot skip past the file data.
+	if (ReductionFactor >= MipLevels) ReductionFactor = MipLevels - 1;
+	MipLevels -= ReductionFactor;
 
 	// Drop the two lowest miplevels!
 	if (MipLevels>2) MipLevels-=2;
@@ -134,41 +131,30 @@ DDSFileClass::DDSFileClass(const char* name,unsigned reduction_factor)
 	Height=SurfaceDesc.Height>>ReductionFactor;
 	Depth=SurfaceDesc.Depth;
 
-	unsigned level_size=Calculate_DXTC_Surface_Size
-	(
-		SurfaceDesc.Width,
-		SurfaceDesc.Height,
-		Format
-	);
 	unsigned level_offset=0;
-
-	unsigned level_mip_dec=4;
-	if (Type==DDS_VOLUME)
-	{
-		// add slices to level data size
-		level_size*=SurfaceDesc.Depth;
-		level_mip_dec=8;
-	}
-
+	unsigned level_width=SurfaceDesc.Width;
+	unsigned level_height=SurfaceDesc.Height;
+	unsigned level_depth=SurfaceDesc.Depth;
 	LevelSizes=W3DNEWARRAY unsigned[MipLevels];
 	LevelOffsets=W3DNEWARRAY unsigned[MipLevels];
 	unsigned level=0;
 	for (;level<ReductionFactor;++level)
 	{
-		if (level_size>16)
-		{	// If surface is bigger than one block (8 or 16 bytes)...
-			level_size/=level_mip_dec;
-		}
+		if (level_width>1) level_width/=2;
+		if (level_height>1) level_height/=2;
+		if (Type==DDS_VOLUME && level_depth>1) level_depth/=2;
 	}
+	// GeneralsX @bugfix Copilot 26/08/2026 Derive each compressed mip size from its logical dimensions.
 	for (level=0;level<MipLevels;++level)
 	{
+		unsigned level_size=Calculate_DXTC_Surface_Size(level_width,level_height,Format);
+		if (Type==DDS_VOLUME) level_size*=level_depth;
 		LevelSizes[level]=level_size;
 		LevelOffsets[level]=level_offset;
 		level_offset+=level_size;
-		if (level_size>16)
-		{	// If surface is bigger than one block (8 or 16 bytes)...
-			level_size/=level_mip_dec;
-		}
+		if (level_width>1) level_width/=2;
+		if (level_height>1) level_height/=2;
+		if (Type==DDS_VOLUME && level_depth>1) level_depth/=2;
 	}
 
 	if (Type==DDS_CUBEMAP)
@@ -247,7 +233,8 @@ unsigned DDSFileClass::Calculate_DXTC_Surface_Size
 	WW3DFormat format
 )
 {
-	unsigned level_size=(width/4)*(height/4);
+	// GeneralsX @bugfix Copilot 24/08/2026 Count at least one compressed block on each axis for narrow rectangular DDS levels.
+	unsigned level_size=max((width+3)/4,1u)*max((height+3)/4,1u);
 	switch (format)
 	{
 	case WW3D_FORMAT_DXT1:
@@ -287,22 +274,19 @@ bool DDSFileClass::Load()
 	}
 
 	// Skip mip levels if reduction factor is not zero
-	unsigned level_size=Calculate_DXTC_Surface_Size
-	(
-		SurfaceDesc.Width,
-		SurfaceDesc.Height,
-		Format
-	);
-
 	unsigned skipped_offset=0;
+	unsigned level_width=SurfaceDesc.Width;
+	unsigned level_height=SurfaceDesc.Height;
+	unsigned level_depth=SurfaceDesc.Depth;
 	for (unsigned i=0;i<ReductionFactor;++i)
 	{
+		unsigned level_size=Calculate_DXTC_Surface_Size(level_width,level_height,Format);
+		if (Type==DDS_VOLUME) level_size*=level_depth;
 		skipped_offset+=level_size;
 		size-=level_size;
-		if (level_size>16)
-		{	// If surface is bigger than one block (8 or 16 bytes)...
-			level_size/=4;
-		}
+		if (level_width>1) level_width/=2;
+		if (level_height>1) level_height/=2;
+		if (Type==DDS_VOLUME && level_depth>1) level_depth/=2;
 	}
 
 	// Skip the header and info block and possible unused mip levels
@@ -1084,7 +1068,8 @@ bool DDSFileClass::Get_4x4_Block(
 	// or we don't.
 	case WW3D_FORMAT_DXT1:
 		{
-			const unsigned char* block_memory=Get_Memory_Pointer(level)+(source_x/4)*8+((source_y/4)*(Get_Width(level)/4))*8;
+			const unsigned blocks_per_row=max((Get_Width(level)+3)/4,1u);
+			const unsigned char* block_memory=Get_Memory_Pointer(level)+(source_x/4)*8+((source_y/4)*blocks_per_row)*8;
 
 			unsigned col0=RGB565_To_ARGB8888(*(unsigned short*)&block_memory[0]);
 			unsigned col1=RGB565_To_ARGB8888(*(unsigned short*)&block_memory[2]);
@@ -1151,7 +1136,8 @@ bool DDSFileClass::Get_4x4_Block(
 	case WW3D_FORMAT_DXT5:
 		{
 			// Init alphas
-			const unsigned char* alpha_block=Get_Memory_Pointer(level)+(source_x/4)*16+((source_y/4)*(Get_Width(level)/4))*16;
+			const unsigned blocks_per_row=max((Get_Width(level)+3)/4,1u);
+			const unsigned char* alpha_block=Get_Memory_Pointer(level)+(source_x/4)*16+((source_y/4)*blocks_per_row)*16;
 
 			unsigned alphas[8];
 			alphas[0]=alpha_block[0];

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/ddsfile.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/ddsfile.h
@@ -214,6 +214,11 @@ public:
 	unsigned long Get_Date_Time() const { return DateTime; }
 
 	unsigned Get_Mip_Level_Count() const { return MipLevels; }
+	// GeneralsX @bugfix Copilot 24/08/2026 Report the usable authored chain independently of thumbnail reduction.
+	unsigned Get_Full_Mip_Level_Count() const {
+		unsigned count=SurfaceDesc.MipMapCount ? SurfaceDesc.MipMapCount : 1;
+		return count>2 ? count-2 : 1;
+	}
 	const unsigned char* Get_Memory_Pointer(unsigned level) const;
 	unsigned Get_Level_Size(unsigned level) const;
 	WW3DFormat Get_Format() const { return Format; }

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/ddsfile.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/ddsfile.cpp
@@ -106,11 +106,9 @@ DDSFileClass::DDSFileClass(const char* name,unsigned reduction_factor)
 	MipLevels=SurfaceDesc.MipMapCount;
 	if (MipLevels==0) MipLevels=1;
 
-	if (MipLevels>ReductionFactor) MipLevels-=ReductionFactor;
-	else {
-		MipLevels=1;
-		ReductionFactor=ReductionFactor-MipLevels;
-	}
+	// GeneralsX @bugfix Copilot 24/08/2026 Clamp DDS reduction to authored levels so thumbnail loads cannot skip past the file data.
+	if (ReductionFactor >= MipLevels) ReductionFactor = MipLevels - 1;
+	MipLevels -= ReductionFactor;
 
 	// Drop the two lowest miplevels!
 	if (MipLevels>2) MipLevels-=2;
@@ -134,41 +132,30 @@ DDSFileClass::DDSFileClass(const char* name,unsigned reduction_factor)
 	Height=SurfaceDesc.Height>>ReductionFactor;
 	Depth=SurfaceDesc.Depth;
 
-	unsigned level_size=Calculate_DXTC_Surface_Size
-	(
-		SurfaceDesc.Width,
-		SurfaceDesc.Height,
-		Format
-	);
 	unsigned level_offset=0;
-
-	unsigned level_mip_dec=4;
-	if (Type==DDS_VOLUME)
-	{
-		// add slices to level data size
-		level_size*=SurfaceDesc.Depth;
-		level_mip_dec=8;
-	}
-
+	unsigned level_width=SurfaceDesc.Width;
+	unsigned level_height=SurfaceDesc.Height;
+	unsigned level_depth=SurfaceDesc.Depth;
 	LevelSizes=W3DNEWARRAY unsigned[MipLevels];
 	LevelOffsets=W3DNEWARRAY unsigned[MipLevels];
 	unsigned level=0;
 	for (;level<ReductionFactor;++level)
 	{
-		if (level_size>16)
-		{	// If surface is bigger than one block (8 or 16 bytes)...
-			level_size/=level_mip_dec;
-		}
+		if (level_width>1) level_width/=2;
+		if (level_height>1) level_height/=2;
+		if (Type==DDS_VOLUME && level_depth>1) level_depth/=2;
 	}
+	// GeneralsX @bugfix Copilot 26/08/2026 Derive each compressed mip size from its logical dimensions.
 	for (level=0;level<MipLevels;++level)
 	{
+		unsigned level_size=Calculate_DXTC_Surface_Size(level_width,level_height,Format);
+		if (Type==DDS_VOLUME) level_size*=level_depth;
 		LevelSizes[level]=level_size;
 		LevelOffsets[level]=level_offset;
 		level_offset+=level_size;
-		if (level_size>16)
-		{	// If surface is bigger than one block (8 or 16 bytes)...
-			level_size/=level_mip_dec;
-		}
+		if (level_width>1) level_width/=2;
+		if (level_height>1) level_height/=2;
+		if (Type==DDS_VOLUME && level_depth>1) level_depth/=2;
 	}
 
 	if (Type==DDS_CUBEMAP)
@@ -238,7 +225,8 @@ unsigned DDSFileClass::Calculate_DXTC_Surface_Size
 	WW3DFormat format
 )
 {
-	unsigned level_size=(width/4)*(height/4);
+	// GeneralsX @bugfix Copilot 24/08/2026 Count at least one compressed block on each axis for narrow rectangular DDS levels.
+	unsigned level_size=max((width+3)/4,1u)*max((height+3)/4,1u);
 	switch (format)
 	{
 	case WW3D_FORMAT_DXT1:
@@ -278,22 +266,19 @@ bool DDSFileClass::Load()
 	}
 
 	// Skip mip levels if reduction factor is not zero
-	unsigned level_size=Calculate_DXTC_Surface_Size
-	(
-		SurfaceDesc.Width,
-		SurfaceDesc.Height,
-		Format
-	);
-
 	unsigned skipped_offset=0;
+	unsigned level_width=SurfaceDesc.Width;
+	unsigned level_height=SurfaceDesc.Height;
+	unsigned level_depth=SurfaceDesc.Depth;
 	for (unsigned i=0;i<ReductionFactor;++i)
 	{
+		unsigned level_size=Calculate_DXTC_Surface_Size(level_width,level_height,Format);
+		if (Type==DDS_VOLUME) level_size*=level_depth;
 		skipped_offset+=level_size;
 		size-=level_size;
-		if (level_size>16)
-		{	// If surface is bigger than one block (8 or 16 bytes)...
-			level_size/=4;
-		}
+		if (level_width>1) level_width/=2;
+		if (level_height>1) level_height/=2;
+		if (Type==DDS_VOLUME && level_depth>1) level_depth/=2;
 	}
 
 	// Skip the header and info block and possible unused mip levels
@@ -1071,7 +1056,8 @@ bool DDSFileClass::Get_4x4_Block(
 	// or we don't.
 	case WW3D_FORMAT_DXT1:
 		{
-			const unsigned char* block_memory=Get_Memory_Pointer(level)+(source_x/4)*8+((source_y/4)*(Get_Width(level)/4))*8;
+			const unsigned blocks_per_row=max((Get_Width(level)+3)/4,1u);
+			const unsigned char* block_memory=Get_Memory_Pointer(level)+(source_x/4)*8+((source_y/4)*blocks_per_row)*8;
 
 			unsigned col0=RGB565_To_ARGB8888(*(unsigned short*)&block_memory[0]);
 			unsigned col1=RGB565_To_ARGB8888(*(unsigned short*)&block_memory[2]);
@@ -1138,7 +1124,8 @@ bool DDSFileClass::Get_4x4_Block(
 	case WW3D_FORMAT_DXT5:
 		{
 			// Init alphas
-			const unsigned char* alpha_block=Get_Memory_Pointer(level)+(source_x/4)*16+((source_y/4)*(Get_Width(level)/4))*16;
+			const unsigned blocks_per_row=max((Get_Width(level)+3)/4,1u);
+			const unsigned char* alpha_block=Get_Memory_Pointer(level)+(source_x/4)*16+((source_y/4)*blocks_per_row)*16;
 
 			unsigned alphas[8];
 			alphas[0]=alpha_block[0];

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/ddsfile.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/ddsfile.h
@@ -214,6 +214,11 @@ public:
 	unsigned long Get_Date_Time() const { return DateTime; }
 
 	unsigned Get_Mip_Level_Count() const { return MipLevels; }
+	// GeneralsX @bugfix Copilot 24/08/2026 Report the usable authored chain independently of thumbnail reduction.
+	unsigned Get_Full_Mip_Level_Count() const {
+		unsigned count=SurfaceDesc.MipMapCount ? SurfaceDesc.MipMapCount : 1;
+		return count>2 ? count-2 : 1;
+	}
 	const unsigned char* Get_Memory_Pointer(unsigned level) const;
 	unsigned Get_Level_Size(unsigned level) const;
 	WW3DFormat Get_Format() const { return Format; }

--- a/docs/WORKLOG/2026-08-DIARY.md
+++ b/docs/WORKLOG/2026-08-DIARY.md
@@ -3,6 +3,11 @@
 > [!NOTE]
 > **AI-Generated Content Disclosure**: This worklog is automatically generated and maintained by AI coding agents to document daily progress, debugging sessions, and technical decisions.
 
+## 26/08/2026
+### Correct Compressed DDS Mip Offsets
+- Calculated every retained and skipped DXT mip size from its own rounded block dimensions instead of dividing the preceding size.
+- Applied the offset correction to both Generals and Zero Hour, including volume-texture depth reduction.
+
 ## 24/08/2026
 ### Preserve Control Bar Card Aspect Ratios on Widescreen Displays
 - Rescaled command buttons, selected-unit cameos, upgrade icons, and production queue buttons uniformly on displays wider than 4:3.
@@ -10,6 +15,13 @@
 - Kept the compact card groups centered inside their existing stretched control bar regions without changing full-width HUD artwork.
 - Built both Generals and Zero Hour successfully with the macOS Vulkan preset.
 - Verified the command-card and selected-unit layout at 3440x1440 and completed a multiplayer replay without a synchronization mismatch.
+
+### Integrate Renderer Quality and Texture Fidelity Fixes
+- Added capability-aware MSAA fallback and anisotropy clamping, with linear filtering when anisotropy is unavailable.
+- Preserved explicit and authored mip counts, generated complete rectangular mip tails from the preceding filtered level, and kept duplicated Generals/Zero Hour DDS metadata handling aligned.
+- Preserved DXT1 fallback alpha and authored skinned-mesh diffuse colors while removing the global lighting/material override that leaked render state across draws.
+- Fixed sparse DDS thumbnails to select only valid authored levels, reject formats without a complete decoder, and downsample narrow or oversized DXT1/DXT5 levels into bounded storage.
+- Validated deterministic edge cases, both WW3D targets, and full macOS ARM64 builds for Generals and Zero Hour.
 
 ## 22/08/2026
 ### CodeRabbit Configuration for Automated PR Reviews


### PR DESCRIPTION
## Summary

- Preserve authored DDS mip chains and explicit mip requests.
- Correct rectangular and sparse mip generation, bounded thumbnail sizing, compressed block strides, and DXT1 alpha handling.
- Fall back through supported MSAA sample counts while validating both color and depth formats.
- Clamp anisotropy to device capabilities and fall back to linear filtering instead of point sampling.
- Preserve authored diffuse, team-color, and emissive vertex colors on skinned meshes without leaking lighting/material state.

## Rationale

The existing paths can silently discard authored mip intent, stop rectangular mip chains early, allocate oversized sparse-DDS thumbnails, degrade unsupported anisotropy to point filtering, or disable MSAA instead of selecting the next supported mode. Skinned rendering also overrides authored vertex colors and leaves global lighting state behind.

These changes keep the existing DX8/DXVK architecture and settings while making capability fallbacks and texture/material behavior explicit. They affect rendering and asset preparation only; no gameplay or serialized simulation state changes.

## Validation

- Built shared Generals and Zero Hour WW3D targets.
- Built full Generals and Zero Hour macOS ARM64 targets.
- Verified identical Generals/Zero Hour DDS behavior.
- Exercised full, sparse, single-level, and narrow rectangular mip chains.
- Exercised 64x64 and 4096x4096 single-mip thumbnail bounds.
- Verified DXT1 alpha, MSAA fallback, anisotropy clamping, and lighting-state restoration.
- Applied the same reviewed production diff to the replay-compatible deterministic branch and completed all 7,535 frames of a multiplayer replay without a synchronization mismatch.

## AI assistance

GitHub Copilot assisted with code tracing, implementation, edge-case generation, and documentation. I consolidated overlapping implementations, rejected unsafe alternatives, reviewed sparse/rectangular DDS edge cases, built both games, and replay-tested the exact local candidate before submission.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added capability-aware MSAA fallback to preserve the highest supported antialiasing mode.
  * Improved anisotropic filtering fallback and applied supported quality levels accurately.
  * Preserved authored skinned-mesh vertex colors during rendering.

* **Bug Fixes**
  * Improved mipmap generation for rectangular and one-dimensional textures.
  * Corrected DDS/DXT mip handling, thumbnail loading, and alpha-preserving DXT1 fallback.
  * Improved texture metadata preservation and thumbnail downsampling.
  * Improved texture filtering and rendering quality on hardware with limited capabilities.

* **Documentation**
  * Added worklog entries covering renderer and texture-quality improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->