### PR TITLE
chore(ci): clarify conventional commit rules for trailers and co-authors

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -20,7 +20,8 @@ reviews:
     Valid types: feat, fix, docs, refactor, test, chore, build, ci, perf, style.
     Use imperative, present tense ("add", "fix", "change"). Do not capitalize the first letter of description.
     Do not end with a period.
-    CRITICAL: Never include the '@' symbol in commit or PR titles (e.g., use 'refactor(graphics): ...' NOT '@refactor(graphics): ...').
+    CRITICAL:
+      - Never include the '@' symbol in PR titles (e.g., use 'refactor(graphics): ...' NOT '@refactor(graphics): ...').
   review_status: true
   review_details: false
   collapse_walkthrough: true
@@ -148,7 +149,9 @@ reviews:
         instructions: "Verify if audio modifications in OpenAL are mirrored in MiniAudio to maintain backend parity."
       - name: "Conventional Commit Standards"
         mode: "error"
-        instructions: "Verify that commit messages follow Conventional Commits format and do NOT contain '@' symbol."
+        instructions: >-
+          Verify that commit subjects/titles follow Conventional Commits format and do NOT contain '@' anywhere in the subject/title (e.g. no '@feat:' or '@refactor:').
+          The '@' symbol IS allowed in commit bodies/footers for emails, mentions, and 'Co-authored-by' trailers.
       - name: "Single Commit / Squash Policy"
         mode: "warning"
         instructions: >-

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,7 +207,7 @@ git merge thesuperhackers/main
 
 ## Git Commit Standards
 - **Conventional Commits**: Format must be `<type>(optional scope): <description>`. (e.g. `fix(audio): restart sound groups in reset`)
-- **DO NOT use `@`**: The commit message (both title and body) must never contain an `@` symbol. The `// GeneralsX @keyword` format is strictly for inline code annotations in C++ files. Do not append these signatures to commit messages.
+- **DO NOT use `@` in subject/type**: The commit subject/title must never contain an `@` symbol (e.g. no `@refactor:`). The `// GeneralsX @keyword` format is strictly for inline code annotations in C++ files and must not be appended to commit messages. Note that `@` is permitted in commit bodies/footers for mentions, emails, and `Co-authored-by` trailers.
 - **Imperative mood**: Use "add", "fix", "change" (not "added" or "fixes").
 - **Read the Docs**: For full details, valid types, and PR standards, you **MUST** read `.github/instructions/git-commit.instructions.md`.
 

--- a/docs/WORKLOG/2026-08-DIARY.md
+++ b/docs/WORKLOG/2026-08-DIARY.md
@@ -3,6 +3,12 @@
 > [!NOTE]
 > **AI-Generated Content Disclosure**: This worklog is automatically generated and maintained by AI coding agents to document daily progress, debugging sessions, and technical decisions.
 
+## 27/08/2026
+### Refine CodeRabbit and Commit Rules for Co-Authors and Trailers
+- Clarified Conventional Commits rules in `.coderabbit.yaml` and `AGENTS.md` to prevent false-positive errors on commit trailers.
+- Restricted the prohibition of `@` symbols strictly to commit/PR types and subjects (e.g., preventing `@feat:` or `@refactor:`), while explicitly permitting `@` in commit bodies and footers for emails, mentions, and `Co-authored-by` trailers.
+- Scoped `auto_title_instructions` strictly to PR title generation.
+
 ## 24/08/2026
 ### Preserve Control Bar Card Aspect Ratios on Widescreen Displays
 - Rescaled command buttons, selected-unit cameos, upgrade icons, and production queue buttons uniformly on displays wider than 4:3.


### PR DESCRIPTION
## Description
Clarifies Conventional Commits instructions and custom pre-merge checks in `.coderabbit.yaml` and `AGENTS.md` to prevent false positive review failures when commits contain `@` in bodies or trailers (such as `Co-authored-by: Name <user@email>` or user mentions).

## Changes
- `.coderabbit.yaml`:
  - Scoped `auto_title_instructions` strictly to PR title generation.
  - Updated `Conventional Commit Standards` custom check to prohibit `@` only as a commit type/subject prefix while explicitly permitting it in commit bodies and footers.
- `AGENTS.md`:
  - Clarified commit rules regarding `@` symbol usage.
- `docs/WORKLOG/2026-08-DIARY.md`:
  - Added diary entry documenting the configuration refinement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified commit and pull request title guidelines.
  * Restricted `@` characters in titles and commit subjects while allowing them in commit bodies and footers.
  * Documented the updated rules in the project worklog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->