### PR TITLE
fix(generals): prevent campaign menu overlay

### DIFF
--- a/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ScoreScreen.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/ScoreScreen.cpp
@@ -174,14 +174,20 @@ void populateSideInfo( UnicodeString side,ScoreGather *sg, Int pos, Color color)
 
 void startNextCampaignGame()
 {
-	TheShell->popImmediate();
-	TheShell->hideShell();
+	// GeneralsX @bugfix arazmj 27/08/2026 Queue the next campaign mission before tearing down the score screen.
 	TheWritableGlobalData->m_pendingFile = TheCampaignManager->getCurrentMap();
-	// send a message to the logic for a new game
+
+	// Shell teardown can initialize an uncovered menu and queue GAME_SHELL, so queue the campaign first.
 	GameMessage *msg = TheMessageStream->appendMessage( GameMessage::MSG_NEW_GAME );
 	msg->appendIntegerArgument(GAME_SINGLE_PLAYER);
 	msg->appendIntegerArgument(TheCampaignManager->getGameDifficulty());
 	msg->appendIntegerArgument(TheCampaignManager->getRankPoints());
+
+	TheShell->popImmediate();
+	TheShell->hideShell();
+
+	// An uncovered menu can also replace the pending file with the shell map during teardown.
+	TheWritableGlobalData->m_pendingFile = TheCampaignManager->getCurrentMap();
 
 	InitRandom(0);
 }

--- a/docs/WORKLOG/2026-08-DIARY.md
+++ b/docs/WORKLOG/2026-08-DIARY.md
@@ -3,6 +3,11 @@
 > [!NOTE]
 > **AI-Generated Content Disclosure**: This worklog is automatically generated and maintained by AI coding agents to document daily progress, debugging sessions, and technical decisions.
 
+## 27/08/2026
+### Prevent the Main Menu From Overlaying Campaign Missions
+- Backported Zero Hour's safe next-mission ordering to Generals.
+- Queued the campaign load before score-screen teardown and restored the campaign map afterward so shell initialization cannot win the transition.
+
 ## 26/08/2026
 ### Correct Compressed DDS Mip Offsets
 - Calculated every retained and skipped DXT mip size from its own rounded block dimensions instead of dividing the preceding size.


### PR DESCRIPTION
## Description

Fixes #272.

Generals removed the campaign score screen before queuing the next mission. Uncovering the main menu during that teardown could queue the shell map first and leave the menu active over the mission.

This backports Zero Hour's safe transition ordering:

- queue the next campaign game before shell teardown
- restore the campaign map afterward if menu initialization replaced it

## Validation

- Built `g_generals` with the `macos-vulkan` preset
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where the main menu could appear over campaign missions when progressing from the score screen.
  - Campaign missions now load the correct map and game settings when starting the next mission.

- **Documentation**
  - Added a worklog entry documenting the campaign mission loading fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->