### PR TITLE
docs: link GeneralsX project website

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@
 
 GeneralsX delivers **Linux and macOS** builds of **Command & Conquer: Generals and Zero Hour** through a single modern codebase.
 
+> [!TIP]
+> Visit the [GeneralsX project website](https://www.amirrazmjou.com/GeneralsX-Website/) for downloads, documentation, community links, and an overview of the cross-platform engine.
+
 ## How to download
 
 For **official releases and instructions**, visit:

--- a/docs/WORKLOG/2026-08-DIARY.md
+++ b/docs/WORKLOG/2026-08-DIARY.md
@@ -3,6 +3,12 @@
 > [!NOTE]
 > **AI-Generated Content Disclosure**: This worklog is automatically generated and maintained by AI coding agents to document daily progress, debugging sessions, and technical decisions.
 
+## 29/08/2026
+### Launch the GeneralsX Project Website
+- Published a standalone Astro website with cinematic project presentation, release downloads, documentation, community links, and responsive GeneralsX artwork.
+- Added validated build-time GitHub release metadata, accessible reduced-motion behavior, media provenance tracking, and independent GitHub Pages deployment.
+- Linked the deployed website from the project README.
+
 ## 28/08/2026
 ### Prepare the Upstream Sync for Merge
 - Merged current `main`, preserved both worklog entries, and resolved the resulting diary conflict.


### PR DESCRIPTION
## Description

- Link the deployed GeneralsX project website from the root README
- Record the website launch in the August 2026 worklog

The standalone website provides project presentation, validated release downloads, documentation and community entry points, responsive GeneralsX artwork, and an independent GitHub Pages deployment.

## Verification

- Confirmed `https://www.amirrazmjou.com/GeneralsX-Website/` and all primary routes are live
- Confirmed the website's Astro checks and production deployment workflow pass
- Documentation-only upstream change; no game build paths are affected

## AI-generated content

The website and this documentation update were generated with AI assistance and reviewed through strict Astro checks, production builds, responsive browser rendering, release-link validation, and live-route verification.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a README tip linking to the GeneralsX project website for downloads, documentation, community resources, and cross-platform engine information.
  * Documented the project website launch, deployment, accessibility, release metadata, and media provenance in the worklog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->