### PR TITLE
fix(cmake): define _MACOSX for GamespySDK so Debug builds compile on macOS

### DIFF
--- a/cmake/gamespy.cmake
+++ b/cmake/gamespy.cmake
@@ -8,3 +8,15 @@ FetchContent_Declare(
 )
 
 FetchContent_MakeAvailable(gamespy)
+
+# The GamespySDK guards its platform-specific code on _MACOSX / _LINUX / _WIN32,
+# but nothing defines _MACOSX on Apple. In Debug the gsinterface target adds
+# GSI_COMMON_DEBUG=1, which compiles gsDebugVaListPrint in gsdebug.c; without
+# _MACOSX that falls through to the dead #else branch, which calls va_start in a
+# function with fixed args and an undeclared gsDebugTTyPrint. Both are hard
+# errors on modern clang, so Debug builds fail while Release (which does not
+# define GSI_COMMON_DEBUG) succeeds. Defining _MACOSX selects the intended
+# vprintf path.
+if(APPLE)
+    target_compile_definitions(gsinterface INTERFACE _MACOSX)
+endif()


### PR DESCRIPTION
Debug builds currently fail to compile on macOS:

```
gsdebug.c:79:5: error: 'va_start' used in function with fixed args
   79 |     va_start(argptr, format);
gsdebug.c:82:5: error: call to undeclared function 'gsDebugTTyPrint'; ISO C99 and later do not support implicit function declarations
   82 |     gsDebugTTyPrint(string);
```

### Cause

The GamespySDK guards its platform-specific code on `_MACOSX` / `_LINUX` / `_WIN32`, but nothing in the build defines `_MACOSX` on Apple.

In Debug, `gsinterface` adds `GSI_COMMON_DEBUG=1`:

```cmake
target_compile_definitions(gsinterface INTERFACE ${GS_COMPILE_DEFS} $<$<CONFIG:DEBUG>:GSI_COMMON_DEBUG=1>)
```

which compiles `gsDebugVaListPrint` in `gsdebug.c`. Without `_MACOSX`, the preprocessor skips the intended branch:

```c
#elif defined(_LINUX) || defined(_MACOSX)
    vprintf(format, params);
```

and falls through to the dead `#else` fallback, which calls `va_start` in a function with fixed args and an undeclared `gsDebugTTyPrint`. Both are hard errors on modern clang.

Release builds do not define `GSI_COMMON_DEBUG`, so the function is never compiled — which is why only Debug is affected.

### Fix

Define `_MACOSX` on the `gsinterface` target for Apple, selecting the intended `vprintf` path. Scoped to `APPLE`, so no other platform is touched.

### Verification

Built the `macos-vulkan` preset with `CMAKE_BUILD_TYPE=Debug` on macOS 26.5, Apple M4, Apple clang 21.0.0, Vulkan SDK 1.4.357.1:

- before: fails at `gsdebug.c`
- after: compiles, links, and the resulting binary starts and initializes SDL3 + MoltenVK normally

Release (`macos-vulkan` as shipped) is unaffected and still builds.

### Note for other macOS contributors

Unrelated to this fix, but worth recording: build with `--target z_generals` as `scripts/build/macos/build-macos-zh.sh` does. Building `all` pulls in `Core/Tools/DebugWindow`, which requires Windows MFC (`afxwin.h`) and cannot compile on macOS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS builds by selecting the appropriate debug logging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->