### PR TITLE
Fix null-pointer crash when skirmish AI fires SCUD Storm special power

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/MissileLauncherBuildingUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/MissileLauncherBuildingUpdate.cpp
@@ -201,14 +201,16 @@ void MissileLauncherBuildingUpdate::switchToState(DoorStateType dst)
 //-------------------------------------------------------------------------------------------------
 Bool MissileLauncherBuildingUpdate::initiateIntentToDoSpecialPower( const SpecialPowerTemplate *specialPowerTemplate, const Object *targetObj, const Coord3D *targetPos, const Waypoint *way, UnsignedInt commandOptions )
 {
-#if RETAIL_COMPATIBLE_CRC
-	// TheSuperHackers @bugfix Mauller 29/06/2025 prevent a game crash when told to launch before ready to do so
+	// TheSuperHackers @bugfix Mauller 29/06/2025 prevent a game crash when told to launch before ready to do so.
+	// Note: RETAIL_COMPATIBLE_CRC is hardcoded to 0 (GameDefines.h), so the guard was compiled out and the
+	// crash still occurs in release builds. The null check must be unconditional.
 	if (!m_specialPowerModule) {
 		Object* us = getObject();
-		us->getSpecialPowerModule(specialPowerTemplate)->setReadyFrame(0xFFFFFFFF);
+		SpecialPowerModuleInterface* spm = us->getSpecialPowerModule(specialPowerTemplate);
+		if (spm)
+			spm->setReadyFrame(0xFFFFFFFF);
 		return FALSE;
 	}
-#endif
 
 	if( m_specialPowerModule->getSpecialPowerTemplate() != specialPowerTemplate )
 	{

--- a/docs/WORKLOG/2026-09-DIARY.md
+++ b/docs/WORKLOG/2026-09-DIARY.md
@@ -1,0 +1,11 @@
+# September 2026
+
+> [!NOTE]
+> **AI-Generated Content Disclosure**: This worklog is automatically generated and maintained by AI coding agents to document daily progress, debugging sessions, and technical decisions.
+
+## 05/09/2026
+### Fix null-pointer crash in MissileLauncherBuildingUpdate special power intent
+- Root-caused macOS skirmish SIGSEGV (issue #284): AI script action `SKIRMISH_FIRE_SPECIAL_POWER_AT_MOST_COST` fires the SCUD Storm special power while the building is still under construction. `update()` skips the `m_specialPowerModule` lazy init in that state, then `initiateIntentToDoSpecialPower()` dereferences the null pointer on the `getSpecialPowerTemplate()` vtable call.
+- The existing TheSuperHackers/Mauller null-check (29/06/2025) was dead code: it is guarded by `#if RETAIL_COMPATIBLE_CRC`, and `GameDefines.h` hardcodes that macro to `0`.
+- Made the null check unconditional and guarded the `getSpecialPowerModule()` result before calling `setReadyFrame()`.
+- Verified against a real crash report (GeneralsXZH Beta 18, macOS arm64): disassembled the shipped binary to confirm the missing guard, then confirmed the fixed build contains the `cbz` null-check and passes a boot smoke test against GeneralsZH assets.


### PR DESCRIPTION
## Summary

`MissileLauncherBuildingUpdate::initiateIntentToDoSpecialPower()` dereferenced `m_specialPowerModule` with no null check in release builds, causing a SIGSEGV when the skirmish AI fires the SCUD Storm special power while the building is still under construction (`update()` skips the lazy init of that pointer in that state).

The null check already exists in the codebase (TheSuperHackers/Mauller, 29/06/2025) but was compiled out: it is wrapped in `#if RETAIL_COMPATIBLE_CRC`, and `Core/GameEngine/Include/Common/GameDefines.h:97` hardcodes `RETAIL_COMPATIBLE_CRC` to `0`. Confirmed against a real crash report (GeneralsXZH Beta 18, macOS arm64) by disassembling the shipped binary, which goes straight from loading `m_specialPowerModule` into a vtable load with no branch.

## Change

- Remove the `#if RETAIL_COMPATIBLE_CRC` guard so the null check applies to all builds.
- Guard the `getSpecialPowerModule()` result before calling `setReadyFrame()` (the previous code dereferenced it unchecked, so the fix itself could crash the same way if the module lookup failed).
- ZH-only: the Generals base-game copy of this function does not dereference `m_specialPowerModule` (checked), so no backport needed.

## Testing

- Built locally on macOS (Apple Silicon, `macos-vulkan` preset).
- Disassembly of the built binary confirms the null check is now emitted (`cbz` before the vtable load), where the shipped binary had none.
- Boot smoke test against GeneralsZH assets: engine launches, renders, and exits cleanly (`GameMain() returned with code 0`).
- The original crash is AI-timing dependent (~24 min into a skirmish), so there is no scripted repro; this change removes the only unchecked null dereference on that code path.

## AI disclosure

This change was authored with AI assistance (Claude Code) and reviewed and verified by the author via disassembly and a local build + boot test.

Closes #284

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented a crash when a missile launcher attempts to activate a special power while its required module is unavailable.
  - Improved stability during building construction and special-power activation.

- **Documentation**
  - Added a worklog entry documenting the fix and verification steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->