### PR TITLE
fix(zh): abort premature SCUD Storm launches

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/SpecialPower/OCLSpecialPower.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/SpecialPower/OCLSpecialPower.cpp
@@ -176,11 +176,9 @@ void OCLSpecialPower::doSpecialPowerAtLocation( const Coord3D *loc, Real angle, 
 	// call the base class action cause we are *EXTENDING* functionality
 	SpecialPowerModule::doSpecialPowerAtLocation( &targetCoord, angle, commandOptions );
 
-#if RETAIL_COMPATIBLE_CRC
-	// TheSuperHackers @info we need to leave early if we are in the MissileLauncherBuildingUpdate crash fix codepath
+	// GeneralsX @bugfix Copilot 06/09/2026 Do not create an OCL after the base special-power intent was rejected.
 	if (m_availableOnFrame == 0xFFFFFFFF)
 		return;
-#endif
 
 	const ObjectCreationList* ocl = findOCL();
 
@@ -244,6 +242,10 @@ void OCLSpecialPower::doSpecialPower( UnsignedInt commandOptions )
 	// call the base class action cause we are *EXTENDING* functionality
 	SpecialPowerModule::doSpecialPowerAtLocation( &creationCoord, INVALID_ANGLE, commandOptions );
 
+	// GeneralsX @bugfix Copilot 06/09/2026 Do not create a targetless OCL after its intent was rejected.
+	if (m_availableOnFrame == 0xFFFFFFFF)
+		return;
+
 	const ObjectCreationList* ocl = findOCL();
 	ObjectCreationList::create( ocl, getObject(), &creationCoord, &creationCoord, false );
 }
@@ -293,4 +295,3 @@ void OCLSpecialPower::loadPostProcess()
 	SpecialPowerModule::loadPostProcess();
 
 }
-

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/SpecialPower/SpecialPowerModule.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/SpecialPower/SpecialPowerModule.cpp
@@ -471,14 +471,14 @@ Bool SpecialPowerModule::initiateIntentToDoSpecialPower( const Object *targetObj
 		}
 	}
 
-#if RETAIL_COMPATIBLE_CRC
-	// TheSuperHackers @info we need to leave early if we are in the MissileLauncherBuildingUpdate crash fix codepath
+	// GeneralsX @bugfix Copilot 06/09/2026 Stop a rejected missile-launcher intent before recording or triggering it.
+	// Upstream reference: Mauller, PR #1218
+	// https://github.com/TheSuperHackers/GeneralsGameCode/pull/1218
 	if (m_availableOnFrame == 0xFFFFFFFF)
 	{
 		DEBUG_ASSERTCRASH(!valid, ("Using MissileLauncherBuildingUpdate escape path when valid is set to true"));
 		return false;
 	}
-#endif
 
 	getObject()->getControllingPlayer()->getAcademyStats()->recordSpecialPowerUsed( getSpecialPowerModuleData()->m_specialPowerTemplate );
 
@@ -741,11 +741,9 @@ void SpecialPowerModule::doSpecialPowerAtLocation( const Coord3D *loc, Real angl
 	//will then start processing each frame.
 	initiateIntentToDoSpecialPower( nullptr, loc, nullptr, commandOptions );
 
-#if RETAIL_COMPATIBLE_CRC
-	// TheSuperHackers @info we need to leave early if we are in the MissileLauncherBuildingUpdate crash fix codepath
+	// GeneralsX @bugfix Copilot 06/09/2026 Do not trigger a location power after its update module rejected the intent.
 	if (m_availableOnFrame == 0xFFFFFFFF)
 		return;
-#endif
 
 	//Only trigger the special power immediately if the updatemodule doesn't start the attack.
 	//An example of a case that wouldn't trigger immediately is for a unit that needs to

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/MissileLauncherBuildingUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/MissileLauncherBuildingUpdate.cpp
@@ -201,14 +201,31 @@ void MissileLauncherBuildingUpdate::switchToState(DoorStateType dst)
 //-------------------------------------------------------------------------------------------------
 Bool MissileLauncherBuildingUpdate::initiateIntentToDoSpecialPower( const SpecialPowerTemplate *specialPowerTemplate, const Object *targetObj, const Coord3D *targetPos, const Waypoint *way, UnsignedInt commandOptions )
 {
-#if RETAIL_COMPATIBLE_CRC
-	// TheSuperHackers @bugfix Mauller 29/06/2025 prevent a game crash when told to launch before ready to do so
-	if (!m_specialPowerModule) {
-		Object* us = getObject();
-		us->getSpecialPowerModule(specialPowerTemplate)->setReadyFrame(0xFFFFFFFF);
+	const MissileLauncherBuildingUpdateModuleData* data = getMissileLauncherBuildingUpdateModuleData();
+	if (data->m_specialPowerTemplate != specialPowerTemplate)
+		return FALSE;
+
+	// GeneralsX @bugfix Copilot 06/09/2026 Abort launch requests made before the special-power module is ready.
+	// Upstream reference: Mauller, PR #1218
+	// https://github.com/TheSuperHackers/GeneralsGameCode/pull/1218
+	Object* us = getObject();
+	if (us->testStatus(OBJECT_STATUS_UNDER_CONSTRUCTION)) {
+		SpecialPowerModuleInterface* specialPowerModule = m_specialPowerModule
+			? const_cast<SpecialPowerModuleInterface*>(m_specialPowerModule)
+			: us->getSpecialPowerModule(data->m_specialPowerTemplate);
+		DEBUG_ASSERTCRASH(specialPowerModule, ("Missing special power"));
+		if (specialPowerModule)
+			specialPowerModule->setReadyFrame(0xFFFFFFFF);
 		return FALSE;
 	}
-#endif
+
+	if (!m_specialPowerModule) {
+		// The cached pointer is intentionally not serialized. Restore it if a loaded, completed
+		// launcher receives a scripted command before its first update.
+		m_specialPowerModule = us->getSpecialPowerModule(data->m_specialPowerTemplate);
+		if (!m_specialPowerModule)
+			return FALSE;
+	}
 
 	if( m_specialPowerModule->getSpecialPowerTemplate() != specialPowerTemplate )
 	{

--- a/docs/WORKLOG/2026-09-DIARY.md
+++ b/docs/WORKLOG/2026-09-DIARY.md
@@ -15,3 +15,12 @@
 - Rejected upstream changes to `.github/workflows/` preserving GeneralsX multi-platform CI and replay validation pipelines.
 - Successfully configured `macos-vulkan` and built both `z_generals` (Zero Hour) and `g_generals` (Generals) binaries; validated clean startup and subsystem initialization for both games.
 - Removed obsolete duplicate `BinkVideoPlayer.h` and `BinkVideoPlayer.cpp` in `GeneralsMD/Code/GameEngineDevice/` that shadowed the canonical `Core` header and caused Windows MSVC builds to fail on abstract `setVolume` instantiation.
+
+## 06/09/2026
+### Abort Premature SCUD Storm Launches
+- Fixed issue #284 by making the existing missile-launcher null guard active in normal builds and safely checking the special-power lookup.
+- Restored the matching escape checks in the base and both OCL special-power paths so a rejected launch cannot continue creating the SCUD Storm effect.
+- Limited the sentinel path to buildings that are actually under construction; completed launchers restore their non-serialized module pointer instead of becoming permanently disabled after loading.
+- Evaluated under-construction status prior to module cache lookup to reject premature launches in all states.
+- Validated each request against the missile launcher's configured power before restoring or rejecting it, so objects with multiple special powers cannot bind the update to an unrelated module.
+- Kept the sentinel temporary: the normal build-complete special-power initialization replaces it with the regular recharge frame.

--- a/docs/WORKLOG/README.md
+++ b/docs/WORKLOG/README.md
@@ -7,6 +7,7 @@ This directory contains chronological monthly development diaries recording tech
 
 ## Monthly Diaries
 
+- [September 2026](2026-09-DIARY.md)
 - [August 2026](file:///Users/felipebraz/PhpstormProjects/pessoal/GeneralsX/docs/WORKLOG/2026-08-DIARY.md)
 - [July 2026](file:///Users/felipebraz/PhpstormProjects/pessoal/GeneralsX/docs/WORKLOG/2026-07-DIARY.md)
 - [June 2026](file:///Users/felipebraz/PhpstormProjects/pessoal/GeneralsX/docs/WORKLOG/2026-06-DIARY.md)


### PR DESCRIPTION
## Description

Fixes #284.

Supersedes #285 by completing the entire escape path introduced upstream in
TheSuperHackers/GeneralsGameCode#1218, not only the initial null guard.

The skirmish AI can request a SCUD Storm while its launcher is still under
construction. In normal GeneralsX builds, the existing guard and all matching
escape checks were compiled out by `RETAIL_COMPATIBLE_CRC=0`, causing a null
dereference. Enabling only the first guard would stop the crash but still allow
the derived OCL path to create the payload.

## Changes

- Validate that the request belongs to the launcher's configured special power.
- Reject under-construction requests without dereferencing a missing cached
  module.
- Guard the special-power lookup before setting the temporary rejection
  sentinel.
- Restore the non-serialized cached module for completed launchers after
  loading.
- Abort before academy statistics, immediate triggering, location OCL creation,
  and targetless OCL creation.
- Preserve the normal build-complete recharge path that replaces the sentinel.

## Validation

- Built `z_generals` with the `macos-vulkan` preset.
- Reviewed the complete call chain and sentinel lifecycle.
- Independently reviewed for loaded-object, multiple-power, targetless OCL, and
  permanent-sentinel edge cases.
- Ran two headless historical replay fixtures; both reached their known
  incompatibility CRCs without crashing in the changed path.

## Attribution

The original crash diagnosis and first null-guard correction were contributed
by @busybee13 in #285 with Claude Code assistance. This PR preserves that
attribution and adds the downstream fixes found during review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented missile-launcher special powers from firing when their launch request is rejected.
  - Blocked premature launches from buildings still under construction.
  - Prevented targetless special-power effects from being created after a rejected request.
  - Improved validation for unavailable or invalid special-power configurations.
  - Ensured rejected special-power attempts are not recorded as used.

- **Documentation**
  - Added the September 2026 development diary and linked it from the worklog index.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->