### PR TITLE
fix(map-preview): escape slashes in flattened preview path

### DIFF
--- a/Core/GameEngine/Source/GameClient/MapUtil.cpp
+++ b/Core/GameEngine/Source/GameClient/MapUtil.cpp
@@ -1195,7 +1195,10 @@ Image *getMapPreviewImage( AsciiString mapName )
 	for(Int i = 0; i < portableName.getLength(); ++i)
 	{
 		char c = portableName.getCharAt(i);
-		if (c == '\\' || c == ':')
+		// GeneralsX @bugfix 09/09/2026 Also escape '/', the path separator used by
+		// StdLocalFileSystem on macOS/Linux; previously only '\' and ':' were
+		// escaped, so custom map previews loaded from disk failed to copy.
+		if (c == '\\' || c == ':' || c == '/')
 			tempName.concat('_');
 		else
 			tempName.concat(c);


### PR DESCRIPTION
On macOS/Linux, custom map paths use `/` (StdLocalFileSystem), but `getMapPreviewImage()` only escaped `\` and `:` when flattening the path for the `MapPreviews/` cache filename. The leftover `/` broke the copy, so custom map previews silently failed to load. Official maps were unaffected since they're read from `.big` archives with hardcoded `\` paths.

Fixes custom map previews on macOS/Linux.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved map preview filename handling for paths that use forward slashes, ensuring consistent previews across platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->