### PR TITLE
fix(skirmish): grow map listbox instead of truncating custom map list

### DIFF
--- a/Core/GameEngine/Source/GameClient/MapUtil.cpp
+++ b/Core/GameEngine/Source/GameClient/MapUtil.cpp
@@ -886,10 +886,12 @@ static Bool addMapToMapListbox(
 			GadgetListBoxSetItemData( lbData.listbox, reinterpret_cast<void*>(std::uintptr_t(imageItemData)), index, 1 );
 		}
 
-		// TheSuperHackers @performance Now stops processing when the list is full.
+		// GeneralsX @bugfix Grow the listbox instead of truncating the custom map list when it fills up.
 		if (index == lbData.numLength - 1)
 		{
-			return false;
+			const Int newLength = lbData.numLength * 2;
+			GadgetListBoxSetListLength( lbData.listbox, newLength );
+			lbData.numLength = newLength;
 		}
 	}
 

--- a/Core/GameEngine/Source/GameClient/MapUtil.cpp
+++ b/Core/GameEngine/Source/GameClient/MapUtil.cpp
@@ -887,7 +887,8 @@ static Bool addMapToMapListbox(
 		}
 
 		// GeneralsX @bugfix UnicodeApocalypse 10/09/2026 Grow the listbox instead of truncating the custom map list when it fills up.
-		if (index == lbData.numLength - 1)
+		// >= instead of == guards against future refactors that add entries in batches or non-sequential order.
+		if (index >= lbData.numLength - 1)
 		{
 			const Int newLength = lbData.numLength * 2;
 			GadgetListBoxSetListLength( lbData.listbox, newLength );

--- a/Core/GameEngine/Source/GameClient/MapUtil.cpp
+++ b/Core/GameEngine/Source/GameClient/MapUtil.cpp
@@ -886,11 +886,18 @@ static Bool addMapToMapListbox(
 			GadgetListBoxSetItemData( lbData.listbox, reinterpret_cast<void*>(std::uintptr_t(imageItemData)), index, 1 );
 		}
 
-		// GeneralsX @bugfix Grow the listbox instead of truncating the custom map list when it fills up.
+		// GeneralsX @bugfix UnicodeApocalypse 10/09/2026 Grow the listbox instead of truncating the custom map list when it fills up.
 		if (index == lbData.numLength - 1)
 		{
 			const Int newLength = lbData.numLength * 2;
 			GadgetListBoxSetListLength( lbData.listbox, newLength );
+
+			// GeneralsX @bugfix UnicodeApocalypse 10/09/2026 Bail out if the resize failed (e.g. allocation failure) instead of assuming growth succeeded.
+			if (GadgetListBoxGetListLength( lbData.listbox ) != newLength)
+			{
+				return false;
+			}
+
 			lbData.numLength = newLength;
 		}
 	}


### PR DESCRIPTION
## Summary

The Skirmish (and Lan/WOL/MapSelect) map-select listbox stopped adding entries once it reached its configured `LISTBOXDATA LENGTH` (100 in the stock `.wnd` layout), silently truncating the custom map list. Players with large custom map collections could not see or select maps beyond that cap.

`addMapToMapListbox()` in `Core/GameEngine/Source/GameClient/MapUtil.cpp` now calls the existing `GadgetListBoxSetListLength()` helper (already used by `GadgetComboBox.cpp` to grow combo boxes on demand) to double the listbox capacity when it fills up, instead of aborting the scan.

## Impact

- Skirmish map selection now shows the full custom map list regardless of how many maps are installed, with no UI/asset changes required.
- Shared code path, so LAN/WOL/single-player map-select menus benefit as well.
- No change to map scanning/caching (`MapCache` was already unbounded) — this only fixes the display layer.
- Low risk: reuses an existing, already-exercised reallocation routine; no ABI or save-compat impact.

## Test plan

- [x] Built `g_generals` (macOS/arm64) and ran locally with ~150 custom Skirmish maps (well past the stock 100-entry cap) with no `.wnd` patch applied — all maps are listed and selectable, no crash/hang.
- [ ] CI build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Map lists now expand reliably when they reach capacity, allowing additional maps to be added.
  * Failed expansions are handled correctly, preventing the map list from reporting space that is not actually available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->