### PR TITLE
fix(assets): give Patch*.big archives priority over base archives

### DIFF
--- a/Core/GameEngineDevice/Include/StdDevice/Common/StdBIGFileSystem.h
+++ b/Core/GameEngineDevice/Include/StdDevice/Common/StdBIGFileSystem.h
@@ -50,6 +50,13 @@ public:
 	virtual void closeAllFiles() override;															///< Close all files associated with ArchiveFiles
 
 	virtual Bool loadBigFilesFromDirectory(AsciiString dir, AsciiString fileMask, Bool overwrite = FALSE) override;
+
+	// GeneralsX @bugfix UnicodeApocalypse 11/09/2026 allowPatchPrecedence=FALSE for fallback asset
+	// roots so their Patch*.big can't outrank content already loaded from the primary root.
+	Bool loadBigFilesFromDirectory(AsciiString dir, AsciiString fileMask, Bool overwrite, Bool allowPatchPrecedence);
 protected:
+	// GeneralsX @bugfix UnicodeApocalypse 11/09/2026 Opens one BIG file and merges it into the directory tree.
+	// Returns TRUE if opened and added.
+	Bool loadOneArchiveFile(const AsciiString& archivePath, Bool overwrite);
 
 };

--- a/Core/GameEngineDevice/Include/Win32Device/Common/Win32BIGFileSystem.h
+++ b/Core/GameEngineDevice/Include/Win32Device/Common/Win32BIGFileSystem.h
@@ -50,6 +50,13 @@ public:
 	virtual void closeAllFiles() override;															///< Close all files associated with ArchiveFiles
 
 	virtual Bool loadBigFilesFromDirectory(AsciiString dir, AsciiString fileMask, Bool overwrite = FALSE) override;
+
+	// GeneralsX @bugfix UnicodeApocalypse 11/09/2026 allowPatchPrecedence=FALSE for fallback asset
+	// roots so their Patch*.big can't outrank content already loaded from the primary root.
+	Bool loadBigFilesFromDirectory(AsciiString dir, AsciiString fileMask, Bool overwrite, Bool allowPatchPrecedence);
 protected:
+	// GeneralsX @bugfix UnicodeApocalypse 11/09/2026 Opens one BIG file and merges it into the directory tree.
+	// Returns TRUE if opened and added.
+	Bool loadOneArchiveFile(const AsciiString& archivePath, Bool overwrite);
 
 };

--- a/Core/GameEngineDevice/Source/StdDevice/Common/StdBIGFileSystem.cpp
+++ b/Core/GameEngineDevice/Source/StdDevice/Common/StdBIGFileSystem.cpp
@@ -69,6 +69,26 @@ static const char* kBaseGeneralsAssetEnv = "CNC_GENERALS_PATH";
 static const char* kBaseGeneralsAssetIniKey = "GeneralsAssetPath";
 #endif
 
+// GeneralsX @bugfix UnicodeApocalypse 11/09/2026 True if the basename starts with "Patch" (e.g. PatchINI.big).
+static Bool isPatchArchiveFilename(const AsciiString& archivePath)
+{
+	const char* raw = archivePath.str();
+	const char* lastSlash = strrchr(raw, '/');
+	const char* lastBackslash = strrchr(raw, '\\');
+	const char* split = lastSlash;
+	if (split == nullptr || (lastBackslash != nullptr && lastBackslash > split)) {
+		split = lastBackslash;
+	}
+
+	const char* baseName = (split != nullptr) ? (split + 1) : raw;
+
+#ifdef _WIN32
+	return _strnicmp(baseName, "Patch", 5) == 0;
+#else
+	return strncasecmp(baseName, "Patch", 5) == 0;
+#endif
+}
+
 static Bool equalsIgnoreCase(const char* lhs, const char* rhs)
 {
 	if (lhs == nullptr || rhs == nullptr) {
@@ -274,15 +294,17 @@ static Bool sanitizeConfiguredPath(const char* rawValue, AsciiString& sanitizedP
 	return sanitizedPath.isNotEmpty();
 }
 
+// GeneralsX @bugfix UnicodeApocalypse 11/09/2026 allowPatchPrecedence must be FALSE for fallback
+// roots so their Patch*.big can't outrank content already loaded from the primary root.
 template <typename TBigFileSystem>
-static Bool tryLoadBigFiles(TBigFileSystem* fileSystem, const AsciiString& directory, const char* sourceTag, Bool overwrite = FALSE)
+static Bool tryLoadBigFiles(TBigFileSystem* fileSystem, const AsciiString& directory, const char* sourceTag, Bool overwrite = FALSE, Bool allowPatchPrecedence = TRUE)
 {
 	if (directory.isEmpty()) {
 		return FALSE;
 	}
 
 	DEBUG_LOG(("StdBIGFileSystem::init - trying '%s' assets directory: %s", sourceTag, directory.str()));
-	const Bool loaded = fileSystem->loadBigFilesFromDirectory(directory, "*.big", overwrite);
+	const Bool loaded = fileSystem->loadBigFilesFromDirectory(directory, "*.big", overwrite, allowPatchPrecedence);
 	if (loaded) {
 		DEBUG_LOG(("StdBIGFileSystem::init - loaded BIG files from %s (%s)", directory.str(), sourceTag));
 	}
@@ -429,21 +451,21 @@ static void loadBaseGeneralsAssetsForZH(TBigFileSystem* fileSystem, const AsciiS
 	// GeneralsX @feature GitHubCopilot 16/03/2026 Resolve base Generals asset directory for ZH by ENV > INI > default.
 	const char* baseEnvValue = getenv(kBaseGeneralsAssetEnv);
 	if (baseEnvValue != nullptr && baseEnvValue[0] != '\0') {
-		if (tryLoadBigFiles(fileSystem, AsciiString(baseEnvValue), "env-generals")) {
+		if (tryLoadBigFiles(fileSystem, AsciiString(baseEnvValue), "env-generals", FALSE, FALSE)) {
 			return;
 		}
 	}
 
 	const char* compatibilityBaseEnvValue = getenv("GENERALSX_GENERALS_ASSET_PATH");
 	if (compatibilityBaseEnvValue != nullptr && compatibilityBaseEnvValue[0] != '\0') {
-		if (tryLoadBigFiles(fileSystem, AsciiString(compatibilityBaseEnvValue), "env-generals-compat")) {
+		if (tryLoadBigFiles(fileSystem, AsciiString(compatibilityBaseEnvValue), "env-generals-compat", FALSE, FALSE)) {
 			return;
 		}
 	}
 
 	const char* legacyGeneralsEnvValue = getenv("CNC_GENERALS_INSTALLPATH");
 	if (legacyGeneralsEnvValue != nullptr && legacyGeneralsEnvValue[0] != '\0') {
-		if (tryLoadBigFiles(fileSystem, AsciiString(legacyGeneralsEnvValue), "legacy-env-generals")) {
+		if (tryLoadBigFiles(fileSystem, AsciiString(legacyGeneralsEnvValue), "legacy-env-generals", FALSE, FALSE)) {
 			return;
 		}
 	}
@@ -453,27 +475,27 @@ static void loadBaseGeneralsAssetsForZH(TBigFileSystem* fileSystem, const AsciiS
 
 	AsciiString iniPath;
 	if (tryResolveFromIni(exeDirectory, kBaseGeneralsAssetIniKey, iniPath)) {
-		if (tryLoadBigFiles(fileSystem, iniPath, "ini-generals")) {
+		if (tryLoadBigFiles(fileSystem, iniPath, "ini-generals", FALSE, FALSE)) {
 			return;
 		}
 	}
 
 	AsciiString installPath;
 	GetStringFromGeneralsRegistry("", "InstallPath", installPath);
-	if (tryLoadBigFiles(fileSystem, installPath, "default-registry-generals")) {
+	if (tryLoadBigFiles(fileSystem, installPath, "default-registry-generals", FALSE, FALSE)) {
 		return;
 	}
 
 	if (zhAssetDirectory.isNotEmpty()) {
 		AsciiString siblingGenerals = zhAssetDirectory;
 		siblingGenerals.concat("/../Generals");
-		if (tryLoadBigFiles(fileSystem, siblingGenerals, "default-sibling-generals")) {
+		if (tryLoadBigFiles(fileSystem, siblingGenerals, "default-sibling-generals", FALSE, FALSE)) {
 			return;
 		}
 
 		AsciiString steamGenerals = zhAssetDirectory;
 		steamGenerals.concat("/ZH_Generals");
-		if (tryLoadBigFiles(fileSystem, steamGenerals, "default-zh-generals")) {
+		if (tryLoadBigFiles(fileSystem, steamGenerals, "default-zh-generals", FALSE, FALSE)) {
 			return;
 		}
 	}
@@ -648,10 +670,37 @@ void StdBIGFileSystem::closeAllArchiveFiles() {
 void StdBIGFileSystem::closeAllFiles() {
 }
 
+Bool StdBIGFileSystem::loadOneArchiveFile(const AsciiString& archivePath, Bool overwrite)
+{
+	// GeneralsX @bugfix UnicodeApocalypse 12/09/2026 Skip archives already loaded (e.g. a ZH_Generals
+	// fallback directory nested under the primary root gets scanned by both); reloading corrupts the tree.
+	if (m_archiveFileMap.find(archivePath) != m_archiveFileMap.end())
+		return FALSE;
+
+	ArchiveFile *archiveFile = openArchiveFile(archivePath.str());
+	if (archiveFile == nullptr) {
+		return FALSE;
+	}
+
+	DEBUG_LOG(("StdBIGFileSystem::loadBigFilesFromDirectory - loading %s into the directory tree.", archivePath.str()));
+	loadIntoDirectoryTree(archiveFile, overwrite);
+	m_archiveFileMap[archivePath] = archiveFile;
+	DEBUG_LOG(("StdBIGFileSystem::loadBigFilesFromDirectory - %s inserted into the archive file map.", archivePath.str()));
+	return TRUE;
+}
+
 Bool StdBIGFileSystem::loadBigFilesFromDirectory(AsciiString dir, AsciiString fileMask, Bool overwrite) {
+	return loadBigFilesFromDirectory(dir, fileMask, overwrite, TRUE);
+}
+
+Bool StdBIGFileSystem::loadBigFilesFromDirectory(AsciiString dir, AsciiString fileMask, Bool overwrite, Bool allowPatchPrecedence) {
 
 	FilenameList filenameList;
 	TheLocalFileSystem->getFileListInDirectory(dir, "", fileMask, filenameList, TRUE);
+
+	// GeneralsX @bugfix UnicodeApocalypse 11/09/2026 Patch*.big must win over same-named base archives
+	// within this root; allowPatchPrecedence=FALSE keeps a fallback root from outranking the primary one.
+	FilenameList patchFilenameList;
 
 	Bool actuallyAdded = FALSE;
 	FilenameListIter it = filenameList.begin();
@@ -666,17 +715,22 @@ Bool StdBIGFileSystem::loadBigFilesFromDirectory(AsciiString dir, AsciiString fi
 		}
 #endif
 
-		ArchiveFile *archiveFile = openArchiveFile((*it).str());
-
-		if (archiveFile != nullptr) {
-			DEBUG_LOG(("StdBIGFileSystem::loadBigFilesFromDirectory - loading %s into the directory tree.", (*it).str()));
-			loadIntoDirectoryTree(archiveFile, overwrite);
-			m_archiveFileMap[(*it)] = archiveFile;
-			DEBUG_LOG(("StdBIGFileSystem::loadBigFilesFromDirectory - %s inserted into the archive file map.", (*it).str()));
+		if (isPatchArchiveFilename(*it)) {
+			patchFilenameList.insert(*it);
+		} else if (loadOneArchiveFile(*it, overwrite)) {
 			actuallyAdded = TRUE;
 		}
 
 		it++;
+	}
+
+	FilenameListIter patchIt = patchFilenameList.begin();
+	while (patchIt != patchFilenameList.end()) {
+		if (loadOneArchiveFile(*patchIt, allowPatchPrecedence ? TRUE : overwrite)) {
+			actuallyAdded = TRUE;
+		}
+
+		patchIt++;
 	}
 
 	return actuallyAdded;

--- a/Core/GameEngineDevice/Source/Win32Device/Common/Win32BIGFileSystem.cpp
+++ b/Core/GameEngineDevice/Source/Win32Device/Common/Win32BIGFileSystem.cpp
@@ -67,6 +67,26 @@ static const char* kBaseGeneralsAssetEnv = "CNC_GENERALS_PATH";
 static const char* kBaseGeneralsAssetIniKey = "GeneralsAssetPath";
 #endif
 
+// GeneralsX @bugfix UnicodeApocalypse 11/09/2026 True if the basename starts with "Patch" (e.g. PatchINI.big).
+static Bool isPatchArchiveFilename(const AsciiString& archivePath)
+{
+	const char* raw = archivePath.str();
+	const char* lastSlash = strrchr(raw, '/');
+	const char* lastBackslash = strrchr(raw, '\\');
+	const char* split = lastSlash;
+	if (split == nullptr || (lastBackslash != nullptr && lastBackslash > split)) {
+		split = lastBackslash;
+	}
+
+	const char* baseName = (split != nullptr) ? (split + 1) : raw;
+
+#ifdef _WIN32
+	return _strnicmp(baseName, "Patch", 5) == 0;
+#else
+	return strncasecmp(baseName, "Patch", 5) == 0;
+#endif
+}
+
 static Bool equalsIgnoreCase(const char* lhs, const char* rhs)
 {
 	if (lhs == nullptr || rhs == nullptr) {
@@ -272,15 +292,17 @@ static Bool sanitizeConfiguredPath(const char* rawValue, AsciiString& sanitizedP
 	return sanitizedPath.isNotEmpty();
 }
 
+// GeneralsX @bugfix UnicodeApocalypse 11/09/2026 allowPatchPrecedence must be FALSE for fallback
+// roots so their Patch*.big can't outrank content already loaded from the primary root.
 template <typename TBigFileSystem>
-static Bool tryLoadBigFiles(TBigFileSystem* fileSystem, const AsciiString& directory, const char* sourceTag, Bool overwrite = FALSE)
+static Bool tryLoadBigFiles(TBigFileSystem* fileSystem, const AsciiString& directory, const char* sourceTag, Bool overwrite = FALSE, Bool allowPatchPrecedence = TRUE)
 {
 	if (directory.isEmpty()) {
 		return FALSE;
 	}
 
 	DEBUG_LOG(("Win32BIGFileSystem::init - trying '%s' assets directory: %s", sourceTag, directory.str()));
-	const Bool loaded = fileSystem->loadBigFilesFromDirectory(directory, "*.big", overwrite);
+	const Bool loaded = fileSystem->loadBigFilesFromDirectory(directory, "*.big", overwrite, allowPatchPrecedence);
 	if (loaded) {
 		DEBUG_LOG(("Win32BIGFileSystem::init - loaded BIG files from %s (%s)", directory.str(), sourceTag));
 	}
@@ -430,21 +452,21 @@ static void loadBaseGeneralsAssetsForZH(TBigFileSystem* fileSystem, const AsciiS
 	// GeneralsX @feature GitHubCopilot 16/03/2026 Resolve base Generals asset directory for ZH by ENV > INI > default.
 	const char* baseEnvValue = getenv(kBaseGeneralsAssetEnv);
 	if (baseEnvValue != nullptr && baseEnvValue[0] != '\0') {
-		if (tryLoadBigFiles(fileSystem, AsciiString(baseEnvValue), "env-generals")) {
+		if (tryLoadBigFiles(fileSystem, AsciiString(baseEnvValue), "env-generals", FALSE, FALSE)) {
 			return;
 		}
 	}
 
 	const char* compatibilityBaseEnvValue = getenv("GENERALSX_GENERALS_ASSET_PATH");
 	if (compatibilityBaseEnvValue != nullptr && compatibilityBaseEnvValue[0] != '\0') {
-		if (tryLoadBigFiles(fileSystem, AsciiString(compatibilityBaseEnvValue), "env-generals-compat")) {
+		if (tryLoadBigFiles(fileSystem, AsciiString(compatibilityBaseEnvValue), "env-generals-compat", FALSE, FALSE)) {
 			return;
 		}
 	}
 
 	const char* legacyGeneralsEnvValue = getenv("CNC_GENERALS_INSTALLPATH");
 	if (legacyGeneralsEnvValue != nullptr && legacyGeneralsEnvValue[0] != '\0') {
-		if (tryLoadBigFiles(fileSystem, AsciiString(legacyGeneralsEnvValue), "legacy-env-generals")) {
+		if (tryLoadBigFiles(fileSystem, AsciiString(legacyGeneralsEnvValue), "legacy-env-generals", FALSE, FALSE)) {
 			return;
 		}
 	}
@@ -454,27 +476,27 @@ static void loadBaseGeneralsAssetsForZH(TBigFileSystem* fileSystem, const AsciiS
 
 	AsciiString iniPath;
 	if (tryResolveFromIni(exeDirectory, kBaseGeneralsAssetIniKey, iniPath)) {
-		if (tryLoadBigFiles(fileSystem, iniPath, "ini-generals")) {
+		if (tryLoadBigFiles(fileSystem, iniPath, "ini-generals", FALSE, FALSE)) {
 			return;
 		}
 	}
 
 	AsciiString installPath;
 	GetStringFromGeneralsRegistry("", "InstallPath", installPath);
-	if (tryLoadBigFiles(fileSystem, installPath, "default-registry-generals")) {
+	if (tryLoadBigFiles(fileSystem, installPath, "default-registry-generals", FALSE, FALSE)) {
 		return;
 	}
 
 	if (zhAssetDirectory.isNotEmpty()) {
 		AsciiString siblingGenerals = zhAssetDirectory;
 		siblingGenerals.concat("/../Generals");
-		if (tryLoadBigFiles(fileSystem, siblingGenerals, "default-sibling-generals")) {
+		if (tryLoadBigFiles(fileSystem, siblingGenerals, "default-sibling-generals", FALSE, FALSE)) {
 			return;
 		}
 
 		AsciiString steamGenerals = zhAssetDirectory;
 		steamGenerals.concat("/ZH_Generals");
-		if (tryLoadBigFiles(fileSystem, steamGenerals, "default-zh-generals")) {
+		if (tryLoadBigFiles(fileSystem, steamGenerals, "default-zh-generals", FALSE, FALSE)) {
 			return;
 		}
 	}
@@ -643,10 +665,37 @@ void Win32BIGFileSystem::closeAllArchiveFiles() {
 void Win32BIGFileSystem::closeAllFiles() {
 }
 
+Bool Win32BIGFileSystem::loadOneArchiveFile(const AsciiString& archivePath, Bool overwrite)
+{
+	// GeneralsX @bugfix UnicodeApocalypse 12/09/2026 Skip archives already loaded (e.g. a ZH_Generals
+	// fallback directory nested under the primary root gets scanned by both); reloading corrupts the tree.
+	if (m_archiveFileMap.find(archivePath) != m_archiveFileMap.end())
+		return FALSE;
+
+	ArchiveFile *archiveFile = openArchiveFile(archivePath.str());
+	if (archiveFile == nullptr) {
+		return FALSE;
+	}
+
+	DEBUG_LOG(("Win32BIGFileSystem::loadBigFilesFromDirectory - loading %s into the directory tree.", archivePath.str()));
+	loadIntoDirectoryTree(archiveFile, overwrite);
+	m_archiveFileMap[archivePath] = archiveFile;
+	DEBUG_LOG(("Win32BIGFileSystem::loadBigFilesFromDirectory - %s inserted into the archive file map.", archivePath.str()));
+	return TRUE;
+}
+
 Bool Win32BIGFileSystem::loadBigFilesFromDirectory(AsciiString dir, AsciiString fileMask, Bool overwrite) {
+	return loadBigFilesFromDirectory(dir, fileMask, overwrite, TRUE);
+}
+
+Bool Win32BIGFileSystem::loadBigFilesFromDirectory(AsciiString dir, AsciiString fileMask, Bool overwrite, Bool allowPatchPrecedence) {
 
 	FilenameList filenameList;
 	TheLocalFileSystem->getFileListInDirectory(dir, "", fileMask, filenameList, TRUE);
+
+	// GeneralsX @bugfix UnicodeApocalypse 11/09/2026 Patch*.big must win over same-named base archives
+	// within this root; allowPatchPrecedence=FALSE keeps a fallback root from outranking the primary one.
+	FilenameList patchFilenameList;
 
 	Bool actuallyAdded = FALSE;
 	FilenameListIter it = filenameList.begin();
@@ -661,17 +710,22 @@ Bool Win32BIGFileSystem::loadBigFilesFromDirectory(AsciiString dir, AsciiString 
 		}
 #endif
 
-		ArchiveFile *archiveFile = openArchiveFile((*it).str());
-
-		if (archiveFile != nullptr) {
-			DEBUG_LOG(("Win32BIGFileSystem::loadBigFilesFromDirectory - loading %s into the directory tree.", (*it).str()));
-			loadIntoDirectoryTree(archiveFile, overwrite);
-			m_archiveFileMap[(*it)] = archiveFile;
-			DEBUG_LOG(("Win32BIGFileSystem::loadBigFilesFromDirectory - %s inserted into the archive file map.", (*it).str()));
+		if (isPatchArchiveFilename(*it)) {
+			patchFilenameList.insert(*it);
+		} else if (loadOneArchiveFile(*it, overwrite)) {
 			actuallyAdded = TRUE;
 		}
 
 		it++;
+	}
+
+	FilenameListIter patchIt = patchFilenameList.begin();
+	while (patchIt != patchFilenameList.end()) {
+		if (loadOneArchiveFile(*patchIt, allowPatchPrecedence ? TRUE : overwrite)) {
+			actuallyAdded = TRUE;
+		}
+
+		patchIt++;
 	}
 
 	return actuallyAdded;


### PR DESCRIPTION
## What this brings
Official patch archives (Patch*.big) now correctly override base
archives on filename conflicts. Fixes the Custom Mission button
popping in instantly instead of animating.

## What was done
`loadBigFilesFromDirectory` loaded BIG files in scan order with
overwrite=FALSE, so the first-loaded archive silently won on
conflicts — patch names don't reliably sort after their base
counterpart (PatchWindow.big even sorts before Window.big). Patch
archives are now deferred to a second pass loaded with
overwrite=TRUE, guaranteeing priority regardless of scan order.
Also extracted the per-archive load logic into a `loadOneArchiveFile`
helper to remove duplication between the two passes.

## Test plan
- Rebuilt GeneralsX and GeneralsXZH, launched both
- Confirmed language auto-detection and all INI subsystems load
  without crashing
- Verified WindowTransitions.ini, MainMenu.wnd and MapSelectMenu.wnd
  now resolve to their patch versions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Patch archives are now loaded after base archives, ensuring patched files consistently override matching original files regardless of scan order.
  - BIG archives are loaded and registered more reliably when scanning directories, including protection against duplicate archive loading.
  - Patch archives from fallback asset locations no longer override content already loaded from the primary game data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->