### PR TITLE
fix(overlord): redirect exit/containment checks to Battle Bunker so riders can disembark

### DIFF
--- a/Generals/Code/GameEngine/Include/GameLogic/Module/ContainModule.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/ContainModule.h
@@ -85,6 +85,8 @@ public:
 	virtual Bool isHealContain() const = 0;
 	virtual Bool isTunnelContain() const = 0;
 	virtual Bool isImmuneToClearBuildingAttacks() const = 0;
+	// GeneralsX @bugfix UnicodeApocalypse 12/09/2026 Ported from GeneralsMD for Overlord-style nested containers.
+	virtual Bool isSpecialOverlordStyleContainer() const = 0;
 
 
 	///< if my object gets selected, then my visible passengers should, too

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/OpenContain.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/OpenContain.h
@@ -193,6 +193,8 @@ public:
 	virtual Bool isTunnelContain() const override { return FALSE; }
 	virtual Bool isSpecialZeroSlotContainer() const override { return false; }
 	virtual Bool isImmuneToClearBuildingAttacks() const override { return true; }
+	// GeneralsX @bugfix UnicodeApocalypse 12/09/2026 Default: not an Overlord-style container.
+	virtual Bool isSpecialOverlordStyleContainer() const override { return false; }
 
 	/**
 		this is used for containers that must do something to allow people to enter or exit...

--- a/Generals/Code/GameEngine/Include/GameLogic/Module/OverlordContain.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Module/OverlordContain.h
@@ -61,6 +61,8 @@ public:
 	virtual Bool isGarrisonable() const override;	///< can this unit be Garrisoned? (ick)
 	virtual Bool isHealContain() const override { return false; } ///< true when container only contains units while healing (not a transport!)
 	virtual Bool isImmuneToClearBuildingAttacks() const override { return true; }
+	// GeneralsX @bugfix UnicodeApocalypse 12/09/2026 The Overlord is a special-style container.
+	virtual Bool isSpecialOverlordStyleContainer() const override { return TRUE; }
 
 	virtual void onDie( const DamageInfo *damageInfo ) override;  ///< the die callback
 	virtual void onDelete() override;	///< Last possible moment cleanup
@@ -75,8 +77,12 @@ public:
 	virtual void redeployOccupants() override;
 	virtual Bool isSpecificRiderFreeToExit(Object* obj) override;
 	virtual void exitObjectViaDoor(Object* exitObj, ExitDoorType exitDoor) override;
+	// GeneralsX @bugfix UnicodeApocalypse 12/09/2026 Redirects exit queries to the loaded portable.
+	virtual ExitInterface* getContainExitInterface() override;
 
 	virtual Bool isValidContainerFor(const Object* obj, Bool checkCapacity) const override;
+	// GeneralsX @bugfix UnicodeApocalypse 12/09/2026 Redirects containment checks to the loaded portable.
+	virtual Bool isContained( const Object *obj ) const override;
 	virtual void addToContain( Object *obj ) override;				///< add 'obj' to contain list
 	virtual void addToContainList( Object *obj ) override;		///< The part of AddToContain that inheritors can override (Can't do whole thing because of all the private stuff involved)
 	virtual void removeFromContain( Object *obj, Bool exposeStealthUnits = FALSE ) override;	///< remove 'obj' from contain list

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OverlordContain.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/OverlordContain.cpp
@@ -152,6 +152,15 @@ void OverlordContain::exitObjectViaDoor(Object* exitObj, ExitDoorType exitDoor)
 	TransportContain::exitObjectViaDoor(exitObj, exitDoor);
 }
 
+// GeneralsX @bugfix UnicodeApocalypse 12/09/2026 Without this, exit/evacuate silently no-ops.
+ExitInterface* OverlordContain::getContainExitInterface()
+{
+	if( getRedirectedContain() == nullptr )
+		return OpenContain::getContainExitInterface();
+
+	return getRedirectedContain()->getContainExitInterface();
+}
+
 //-------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------
 void OverlordContain::onBodyDamageStateChange( const DamageInfo* damageInfo,
@@ -396,6 +405,15 @@ Bool OverlordContain::isValidContainerFor(const Object* obj, Bool checkCapacity)
 		return TransportContain::isValidContainerFor( obj, checkCapacity );
 
 	return getRedirectedContain()->isValidContainerFor( obj, checkCapacity );
+}
+
+// GeneralsX @bugfix UnicodeApocalypse 12/09/2026 Without this, privateExit's isContained() guard blocks all exits.
+Bool OverlordContain::isContained( const Object *obj ) const
+{
+	if( getRedirectedContain() == nullptr )
+		return OpenContain::isContained( obj );
+
+	return getRedirectedContain()->isContained( obj );
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/TransportContain.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Contain/TransportContain.cpp
@@ -470,9 +470,12 @@ Bool TransportContain::isSpecificRiderFreeToExit(Object* specificObject)
 #if !RETAIL_COMPATIBLE_CRC
 	// TheSuperHackers @bugfix Stubbjax/bobtista 01/08/2026 If our container is itself contained,
 	// then we are not free to exit.
+	// GeneralsX @bugfix UnicodeApocalypse 12/09/2026 Except for special Overlord-style containers (e.g. Battle Bunker).
 	if (me->isContained())
 	{
-		return FALSE;
+		const ContainModuleInterface* outerContain = me->getContainedBy()->getContain();
+		if (outerContain == nullptr || !outerContain->isSpecialOverlordStyleContainer())
+			return FALSE;
 	}
 #endif
 

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/OverlordContain.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Module/OverlordContain.h
@@ -77,6 +77,8 @@ public:
 	virtual Bool isPassengerAllowedToFire( ObjectID id = INVALID_ID ) const override;	///< Hey, can I shoot out of this container?
 	virtual Bool isSpecificRiderFreeToExit(Object* obj) override;
 	virtual void exitObjectViaDoor(Object* exitObj, ExitDoorType exitDoor) override;
+	// GeneralsX @bugfix UnicodeApocalypse 12/09/2026 Redirects exit queries to the loaded portable.
+	virtual ExitInterface* getContainExitInterface() override;
 
 
 	virtual void onDie( const DamageInfo *damageInfo ) override;  ///< the die callback
@@ -97,6 +99,8 @@ private:
 
 
 	virtual Bool isValidContainerFor(const Object* obj, Bool checkCapacity) const override;
+	// GeneralsX @bugfix UnicodeApocalypse 12/09/2026 Redirects containment checks to the loaded portable.
+	virtual Bool isContained( const Object *obj ) const override;
 	virtual void addToContain( Object *obj ) override;				///< add 'obj' to contain list
 	virtual void addToContainList( Object *obj ) override;		///< The part of AddToContain that inheritors can override (Can't do whole thing because of all the private stuff involved)
 	virtual void removeFromContain( Object *obj, Bool exposeStealthUnits = FALSE ) override;	///< remove 'obj' from contain list

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OverlordContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/OverlordContain.cpp
@@ -182,6 +182,15 @@ void OverlordContain::exitObjectViaDoor(Object* exitObj, ExitDoorType exitDoor)
 	TransportContain::exitObjectViaDoor(exitObj, exitDoor);
 }
 
+// GeneralsX @bugfix UnicodeApocalypse 12/09/2026 Without this, exit/evacuate silently no-ops.
+ExitInterface* OverlordContain::getContainExitInterface()
+{
+	if( getRedirectedContain() == nullptr )
+		return OpenContain::getContainExitInterface();
+
+	return getRedirectedContain()->getContainExitInterface();
+}
+
 //-------------------------------------------------------------------------------------------------
 // ------------------------------------------------------------------------------------------------
 void OverlordContain::createPayload()
@@ -507,6 +516,15 @@ Bool OverlordContain::isValidContainerFor(const Object* obj, Bool checkCapacity)
 		return TransportContain::isValidContainerFor( obj, checkCapacity );
 
 	return getRedirectedContain()->isValidContainerFor( obj, checkCapacity );
+}
+
+// GeneralsX @bugfix UnicodeApocalypse 12/09/2026 Without this, privateExit's isContained() guard blocks all exits.
+Bool OverlordContain::isContained( const Object *obj ) const
+{
+	if( getRedirectedContain() == nullptr )
+		return OpenContain::isContained( obj );
+
+	return getRedirectedContain()->isContained( obj );
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/TransportContain.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Contain/TransportContain.cpp
@@ -581,9 +581,12 @@ Bool TransportContain::isSpecificRiderFreeToExit(Object* specificObject)
 #if !RETAIL_COMPATIBLE_CRC
 	// TheSuperHackers @bugfix Stubbjax/bobtista 01/08/2026 If our container is itself contained,
 	// then we are not free to exit.
+	// GeneralsX @bugfix UnicodeApocalypse 12/09/2026 Except for special Overlord-style containers (e.g. Battle Bunker).
 	if (me->isContained())
 	{
-		return FALSE;
+		const ContainModuleInterface* outerContain = me->getContainedBy()->getContain();
+		if (outerContain == nullptr || !outerContain->isSpecialOverlordStyleContainer())
+			return FALSE;
 	}
 #endif
 


### PR DESCRIPTION
## What this brings
Infantry loaded into an Overlord's Battle Bunker upgrade could no
longer be ordered to exit — neither the individual disembark buttons
nor "Evacuate" worked, in both Generals and Zero Hour.

## What was done
`OverlordContain` redirects most containment queries to the Battle
Bunker once it's loaded, but three methods weren't redirected:
- `isContained()` — `AIUpdateInterface::privateExit`'s safety guard
  checked it against the Overlord's own (near-empty) list and
  silently aborted every exit attempt before it started.
- `getContainExitInterface()` — caused door reservation/exit to
  operate on the Overlord instead of the Battle Bunker.
- `isSpecificRiderFreeToExit()`'s nested-container guard also
  blocked riders since the Battle Bunker is itself contained in the
  Overlord; added an exemption for special Overlord-style containers.

`isSpecialOverlordStyleContainer()` didn't exist in the base Generals
engine at all (Zero Hour only), so it's now ported over.

## Test plan
- Rebuilt GeneralsX and GeneralsXZH, launched both, no crash
- Confirmed via targeted logging that the exit path now reaches
  `exitObjectViaDoor` on the Battle Bunker instead of aborting early
- Manually verified in-game: individual disembark and Evacuate both
  work on an Overlord with Battle Bunker loaded


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed exit and evacuation behavior for units contained within Overlord-style containers.
  * Contained transports can now exit Overlord-style containers while remaining blocked from other container types.
  * Corrected containment checks when redirected containers are active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->